### PR TITLE
fix: prevent null point exception when attaching a CH document

### DIFF
--- a/husky-communication/husky-communication-ch/src/main/java/org/projecthusky/communication/ch/ConvenienceCommunicationCh.java
+++ b/husky-communication/husky-communication-ch/src/main/java/org/projecthusky/communication/ch/ConvenienceCommunicationCh.java
@@ -10,6 +10,7 @@
  */
 package org.projecthusky.communication.ch;
 
+import org.openehealth.ipf.commons.ihe.xds.core.metadata.DocumentEntry;
 import org.projecthusky.common.ch.AuthorCh;
 import org.projecthusky.common.ch.enums.stable.AuthorRole;
 import org.projecthusky.common.communication.AffinityDomain;
@@ -122,6 +123,7 @@ public class ConvenienceCommunicationCh extends ConvenienceCommunication {
 			}
 		var doc = new Document();
 		var doc4Metadata = new Document();
+		doc4Metadata.setDocumentEntry(new DocumentEntry());
 		InputStream unicodeStream = null;
 		try {
 


### PR DESCRIPTION
The PR fix a null point pointer exception when adding a document with `ConvenienceCommunicationCh.addChDocument`.