### PR TITLE
[https://github.com/project-husky/husky/issues/94] Bugfix Concurrency

### DIFF
--- a/husky-communication/husky-communication-gen/src/test/java/org/projecthusky/communication/ConvenienceCommunicationTest.java
+++ b/husky-communication/husky-communication-gen/src/test/java/org/projecthusky/communication/ConvenienceCommunicationTest.java
@@ -1,0 +1,94 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0 in the github
+ * project https://github.com/project-husky/husky there you also find a list of the contributors and
+ * the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky on the
+ * basis of the eHealth Connector opensource project from June 28, 2021, whereas medshare GmbH is
+ * the initial and main contributor/author of the eHealth Connector.
+ *
+ */
+package org.projecthusky.communication;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.Test;
+import org.projecthusky.common.communication.AffinityDomain;
+import org.projecthusky.common.communication.Destination;
+import org.projecthusky.common.communication.DocumentMetadata;
+import org.projecthusky.common.communication.SubmissionSetMetadata;
+import org.projecthusky.common.enums.DocumentDescriptor;
+import org.projecthusky.common.model.Identificator;
+import org.projecthusky.communication.testhelper.XdsTestUtils;
+import org.projecthusky.xua.core.SecurityHeaderElement;
+
+/**
+ * Tests {@link ConvenienceCommunication}
+ */
+public class ConvenienceCommunicationTest extends XdsTestUtils {
+  private static final String HTTP_LITERAL = "http://";
+  private static final String ROOT = "1.3.6.1.4.1.21367.13.20.1000";
+  private static final String EXTENSION = "IHERED-1024";
+  private static final Integer NUMBER_OF_THREADS = 100;
+
+  @Test
+  public void submitConcurrency_multipleThreadsDifferentDomains_affinityDomainIsNotOverwrittenByOtherThread()
+      throws InterruptedException {
+    Set<String> endpoints = new HashSet<>();
+    ConvenienceCommunication comm = new ConvenienceCommunication() {
+      @Override
+      protected Exchange send(String endpoint, Object body, SecurityHeaderElement securityHeaderElement,
+          String messageId,
+          Map<String, String> outgoingHttpHeaders) {
+        assertTrue(endpoint.contains(Thread.currentThread().getName()));
+        endpoints.add(endpoint);
+        return null;
+      }
+    };
+
+    ExecutorService service = Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+
+    List<Callable<Void>> callable = new ArrayList<>();
+    for (int i = 0; i < NUMBER_OF_THREADS; i++) {
+      int threadNumber = i;
+      callable.add(() -> {
+        String threadName = Thread.currentThread().getName();
+        Destination dest = new Destination();
+        dest.setUri(new URI(HTTP_LITERAL + threadName));
+        dest.setSenderApplicationOid(String.valueOf(threadNumber));
+        AffinityDomain domain = new AffinityDomain();
+        domain.setRegistryDestination(dest);
+        domain.setRepositoryDestination(dest);
+
+        // Rest is mock data to ensure that submit method triggers the send method correctly
+        DocumentMetadata metadata = comm.addDocument(DocumentDescriptor.PDF, getDocPdf());
+
+        SubmissionSetMetadata subSetStub = new SubmissionSetMetadata();
+        Identificator patientId = new Identificator(ROOT, EXTENSION);
+        setMetadataForPdf(metadata, patientId);
+        setSubmissionMetadata(subSetStub, patientId);
+
+        comm.setAffinityDomain(domain);
+        comm.submit(subSetStub, null, null);
+        return null;
+      });
+    }
+    service.invokeAll(callable);
+
+    // wait for all threads to be finished, there must be exactly the same number
+    // of domains as there are threads, otherwise one domain was overwritten by another
+    Thread.sleep(200);
+    assertEquals(NUMBER_OF_THREADS, endpoints.size());
+  }
+}


### PR DESCRIPTION
- use ThreadLocal for Convenience Communication class in order to make affirmityDomain and TnxData threadsafe
- please node that the configuration parameters (atnaConfigMode, documentMetadataExtractionmode, submissionSetMetadataExtractionMode) are still not threadsafe, however, those should be fine being modified once during set up