### PR TITLE
Fix the XUA claims dialect

### DIFF
--- a/husky-communication/husky-xua/husky-xua-ch-impl/src/main/java/org/projecthusky/xua/ChEprXuaSpecifications.java
+++ b/husky-communication/husky-xua/husky-xua-ch-impl/src/main/java/org/projecthusky/xua/ChEprXuaSpecifications.java
@@ -59,5 +59,5 @@ public class ChEprXuaSpecifications {
     /**
      * The claims dialect (in Get X-User Assertion requests).
      */
-    public static final String CLAIMS_DIALECT = "http://bag.admin.ch/epr/2017/annex/5/addendum/2";
+    public static final String CLAIMS_DIALECT = "http://www.bag.admin.ch/epr/2017/annex/5/amendment/2";
 }

--- a/husky-communication/husky-xua/husky-xua-gen-impl/src/test/java/org/projecthusky/xua/communication/xua/impl/XUserAssertionRequestBuilderImplTest.java
+++ b/husky-communication/husky-xua/husky-xua-gen-impl/src/test/java/org/projecthusky/xua/communication/xua/impl/XUserAssertionRequestBuilderImplTest.java
@@ -55,7 +55,7 @@ class XUserAssertionRequestBuilderImplTest {
 	@BeforeEach
 	public void setUp() throws Exception {
 		builder = new XUserAssertionRequestBuilderImpl();
-		testDialect = "http://bag.admin.ch/epr/2017/annex/5/addendum/2";
+		testDialect = "http://www.bag.admin.ch/epr/2017/annex/5/amendment/2";
 		testContext = "This is my Context";
 		testSubjectId = UUID.randomUUID().toString();
 		testSubjectName = "Harry Hirsch";

--- a/husky-communication/husky-xua/husky-xua-gen-impl/src/test/java/org/projecthusky/xua/serialization/impl/XUserAssertionRequestSerializerImplTest.java
+++ b/husky-communication/husky-xua/husky-xua-gen-impl/src/test/java/org/projecthusky/xua/serialization/impl/XUserAssertionRequestSerializerImplTest.java
@@ -35,7 +35,7 @@ class XUserAssertionRequestSerializerImplTest {
 	public void setUp() throws Exception {
 		testSerializer = new XUserAssertionRequestSerializerImpl();
 
-		testDialect = "http://bag.admin.ch/epr/2017/annex/5/addendum/2";
+		testDialect = "http://www.bag.admin.ch/epr/2017/annex/5/amendment/2";
 		testContext = "This is my Context";
 		
 		InitializationService.initialize();


### PR DESCRIPTION
As per current Amendment 1 of Annex 5 EPRO-FDHA:

> In addition to the elements defined in WS-Trust 1.3, the Get X-User Assertion request MUST contain a <wst:Claims> element with the Dialect set to "http://www.bag.admin.ch/epr/2017/annex/5/amendment/2".