### PR TITLE
Emed: fix URN-encoding of OIDs

### DIFF
--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedEprDosage.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedEprDosage.java
@@ -171,7 +171,7 @@ public class ChEmedEprDosage extends Dosage {
     public ChEmedEprDosage setRouteOfAdministration(final RouteOfAdministrationEdqm routeOfAdministration) {
         this.getRoute()
                 .getCodingFirstRep()
-                .setSystem(Oids.PREFIX_OID + routeOfAdministration.getCodeSystemId())
+                .setSystem(Oids.PREFIX_OID + Oids.normalize(routeOfAdministration.getCodeSystemId()))
                 .setCode(routeOfAdministration.getCodeValue())
                 .setDisplay(routeOfAdministration.getDisplayName());
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationIngredient.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationIngredient.java
@@ -75,7 +75,7 @@ public class ChEmedEprMedicationIngredient extends Medication.MedicationIngredie
         this.getItemCodeableConcept()
                 .setText(ingredient.getDisplayName())
                 .getCodingFirstRep()
-                .setSystem(Oids.PREFIX_OID + ingredient.getCodeSystemId())
+                .setSystem(Oids.PREFIX_OID + Oids.normalize(ingredient.getCodeSystemId()))
                 .setCode(ingredient.getCodeValue())
                 .setDisplay(ingredient.getDisplayName());
 


### PR DESCRIPTION
In our value sets, OIDs are sometimes URN-encoded, sometimes not. This PR fixes setting the system in emedication classes.