### PR TITLE
eMed improvements

### DIFF
--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-common/src/main/java/org/projecthusky/fhir/emed/ch/common/datatype/ChCoreAddressAdapter.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-common/src/main/java/org/projecthusky/fhir/emed/ch/common/datatype/ChCoreAddressAdapter.java
@@ -87,9 +87,11 @@ public class ChCoreAddressAdapter {
      * OFS</a>
      * @see <a href="https://www.bfs.admin.ch/bfs/it/home/basi-statistiche/elenco-ufficiale-comuni-svizzera.html">Numero
      * UST</a>
+     * @return this.
      */
-    public void setCityBfs(@Nullable final String bfs) {
+    public ChCoreAddressAdapter setCityBfs(@Nullable final String bfs) {
         this.address.getCityElement().addExtension(BFS_EXTENSION, new StringType(bfs));
+        return this;
     }
 
     /**
@@ -106,9 +108,11 @@ public class ChCoreAddressAdapter {
      * Sets the country code (ISO Country Alpha-2 or ISO Country Alpha-3 code).
      *
      * @param countryCode The country code (ISO Country Alpha-2 or ISO Country Alpha-3 code).
+     * @return this.
      */
-    public void setCountryCode(@Nullable final String countryCode) {
+    public ChCoreAddressAdapter setCountryCode(@Nullable final String countryCode) {
         this.address.getCountryElement().addExtension(COUNTRY_CODE_EXTENSION, new StringType(countryCode));
+        return this;
     }
 
     /**
@@ -124,9 +128,11 @@ public class ChCoreAddressAdapter {
      * Adds an address line.
      *
      * @param addressLineAdapter The address line adapter.
+     * @return this.
      */
-    public void addLine(final AddressLineAdapter addressLineAdapter) {
+    public ChCoreAddressAdapter addLine(final AddressLineAdapter addressLineAdapter) {
         this.address.getLine().add(addressLineAdapter.getLine());
+        return this;
     }
 
     public static final class AddressLineAdapter {

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/last_modif.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/last_modif.html
@@ -10,10 +10,10 @@
 
 <th:block th:fragment="display-last-modification(lastStatement, lang)">
   <th:block th:if="${lastStatement.resolveInformationSource.patient != null}">
-    <th:block th:include="~{datatypes :: human-name(${lastStatement.resolveInformationSource.patient.name[0]}, ${lang})}"/>
+    <th:block th:insert="~{datatypes :: human-name(${lastStatement.resolveInformationSource.patient.name[0]}, ${lang})}"/>
   </th:block>
   <th:block th:if="${lastStatement.resolveInformationSource.practitionerRole != null}">
-    <th:block th:include="~{datatypes :: human-name(${lastStatement.resolveInformationSource.practitionerRole.resolvePractitioner.name[0]}, ${lang})}"/>
+    <th:block th:insert="~{datatypes :: human-name(${lastStatement.resolveInformationSource.practitionerRole.resolvePractitioner.name[0]}, ${lang})}"/>
   </th:block>
   (<th:block th:insert="~{datatypes :: instant(${lastStatement.resolveInformationSource.time}, ${lang})}"/>)
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/organization.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/organization.html
@@ -10,13 +10,13 @@
   -->
 
 <th:block th:fragment="display-name-address-contact(organization, lang)">
-    <th:block th:if="${organization.hasName()}">[[${organization.name}]]</th:block>
-    <th:block th:if="${!organization.hasName() && organization.hasAlias()}">[[${organization.alias[0]}]]</th:block>
+    <th:block th:if="${organization.hasName()}">[[${organization.name}]]<br/></th:block>
+    <th:block th:if="${!organization.hasName() && organization.hasAlias()}">[[${organization.alias[0]}]]<br/></th:block>
 
     <th:block th:insert="~{datatypes :: address(${organization.resolveAddress()}, ${lang})}"/>
     <th:block th:if="${organization.hasTelecom()}">
         <th:block th:each="contactPoint : ${organization.telecom}">
-            <th:block th:insert="~{datatypes :: contact-point(${contactPoint}, ${lang})}"/>
+            <th:block th:insert="~{datatypes :: contact-point(${contactPoint}, ${lang})}"/><br/>
         </th:block>
     </th:block>
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/organization.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/organization.html
@@ -1,0 +1,22 @@
+<!--
+  ~ This code is made available under the terms of the Eclipse Public License v1.0
+  ~ in the github project https://github.com/project-husky/husky there you also
+  ~ find a list of the contributors and the license information.
+  ~
+  ~ This project has been developed further and modified by the joined working group Husky
+  ~ on the basis of the eHealth Connector opensource project from June 28, 2021,
+  ~ whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+  ~
+  -->
+
+<th:block th:fragment="display-name-address-contact(organization, lang)">
+    <th:block th:if="${organization.hasName()}">[[${organization.name}]]</th:block>
+    <th:block th:if="${!organization.hasName() && organization.hasAlias()}">[[${organization.alias[0]}]]</th:block>
+
+    <th:block th:insert="~{datatypes :: address(${organization.resolveAddress()}, ${lang})}"/>
+    <th:block th:if="${organization.hasTelecom()}">
+        <th:block th:each="contactPoint : ${organization.telecom}">
+            <th:block th:insert="~{datatypes :: contact-point(${contactPoint}, ${lang})}"/>
+        </th:block>
+    </th:block>
+</th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/patient.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/patient.html
@@ -9,9 +9,7 @@
   */-->
 
 <th:block th:fragment="display-name-address-contact(patient, lang)">
-    <th:block th:if="${patient.hasName()}">
-        <th:block th:insert="~{datatypes :: human-name(${patient.name[0]}, ${lang})}"/>
-    </th:block>
-    (<th:block th:if="${patient.hasBirthDateElement()}"
-               th:insert="~{datatypes :: date-time(${patient.getBirthDateElement()}, ${lang})}"/>)
+    <th:block th:insert="~{datatypes :: human-name(${patient.name[0]}, ${lang})}"/><br/>
+    <th:block th:text="${#strings.substring(patient.resolveGender().getDisplay(), 0, 1)}"/> /
+    <th:block th:insert="~{datatypes :: date-time(${patient.getBirthDateElement()}, ${lang})}"/>
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner.html
@@ -9,7 +9,7 @@
   ~
   -->
 
-<th:block th:fragment="display-name(device, lang)">
-    <th:block th:each="deviceName: ${device.deviceName}">[[${deviceName.name}]] ([[${deviceName.type.getDisplay()}]])</th:block>
-    <th:block th:if="${device.hasManufacturer()}">Manufacturer: [[${device.manufacturer}]]</th:block>
+<th:block th:fragment="display-name-gln(practitioner, lang)">
+    <th:block th:insert="~{datatypes :: human-name(${practitioner.name[0]}, ${lang})}"/>
+    GLN: <span th:text="${practitioner.resolveGln()}"/>
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner.html
@@ -10,6 +10,6 @@
   -->
 
 <th:block th:fragment="display-name-gln(practitioner, lang)">
-    <th:block th:insert="~{datatypes :: human-name(${practitioner.name[0]}, ${lang})}"/>
+    <th:block th:insert="~{datatypes :: human-name(${practitioner.name[0]}, ${lang})}"/><br/>
     GLN: <span th:text="${practitioner.resolveGln()}"/>
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner_role.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner_role.html
@@ -9,7 +9,7 @@
   ~
   -->
 
-<th:block th:fragment="display-name(device, lang)">
-    <th:block th:each="deviceName: ${device.deviceName}">[[${deviceName.name}]] ([[${deviceName.type.getDisplay()}]])</th:block>
-    <th:block th:if="${device.hasManufacturer()}">Manufacturer: [[${device.manufacturer}]]</th:block>
+<th:block th:fragment="display(practitionerrole, lang)">
+    <th:block th:insert="~{practitioner :: display-name-gln(${practitionerrole.resolvePractitioner()}, ${lang})}"/>
+    <th:block th:insert="~{organization :: display-name-address-contact(${practitionerrole.resolveOrganization()}, ${lang})}"/>
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner_role.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/practitioner_role.html
@@ -10,6 +10,6 @@
   -->
 
 <th:block th:fragment="display(practitionerrole, lang)">
-    <th:block th:insert="~{practitioner :: display-name-gln(${practitionerrole.resolvePractitioner()}, ${lang})}"/>
+    <th:block th:insert="~{practitioner :: display-name-gln(${practitionerrole.resolvePractitioner()}, ${lang})}"/><br/>
     <th:block th:insert="~{organization :: display-name-address-contact(${practitionerrole.resolveOrganization()}, ${lang})}"/>
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/prescription.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/prescription.html
@@ -1,4 +1,4 @@
-<!--/*
+<!--
   ~ This code is made available under the terms of the Eclipse Public License v1.0
   ~ in the github project https://github.com/project-husky/husky there you also
   ~ find a list of the contributors and the license information.
@@ -6,9 +6,10 @@
   ~ This project has been developed further and modified by the joined working group Husky
   ~ on the basis of the eHealth Connector opensource project from June 28, 2021,
   ~ whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
-  */-->
+  ~
+  -->
 <th:block th:switch="${lang.name()}">
-    <h1 id="card-title">Carte de médication</h1>
+    <h1 id="card-title">Prescription</h1>
 
     <table class="table-header">
         <tr>
@@ -16,21 +17,15 @@
                 <h2>Patient</h2>
                 <th:block th:insert="~{patient :: display-name-address-contact(${resource.resolvePatient()}, ${lang})}"/>
             </td>
-            <th:block th:if="${lastStatement != null}">
-                <td class="cell-author">
-                    <h2>Dernière modification</h2>
-                    <th:block th:insert="~{last_modif :: display-last-modification(${lastStatement}, ${lang})}"/>
-                </td>
-            </th:block>
+            <td class="cell-author">
+                <h2>Auteur</h2>
+                <th:block th:insert="~{practitioner_role :: display(${author}, ${lang})}"/>
+            </td>
         </tr>
     </table>
 
-    <div id="active-treatments">
-        <h2 id="active-treatments-header">Traitements actifs</h2>
-        <th:block th:insert="~{medication_card_fragments :: table(${activeTreatments}, ${lang})}"/>
-    </div>
-    <div id="reserve-treatments">
-        <h2 id="reserve-treatments-header">Traitements en réserve</h2>
-        <th:block th:insert="~{medication_card_fragments :: table(${asneededTreatments}, ${lang})}"/>
+    <div id="treatments">
+        <h2 id="treatments-header">Traitements</h2>
+        <th:block th:insert="~{prescription_fragments :: table(${treatments}, ${lang})}"/>
     </div>
 </th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/prescription_fragments.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/prescription_fragments.html
@@ -12,7 +12,7 @@
 <table th:fragment="table(requests, lang)">
     <thead>
     <tr>
-        <td rowspan="2" colspan="2">Nom du médicament</td>
+        <td rowspan="2">Nom du médicament</td>
         <td colspan="4">Dosage</td>
         <td rowspan="2">Commentaire</td>
         <td rowspan="2">Voie et localisation</td>
@@ -32,10 +32,7 @@
 </table>
 
 <th:block th:fragment="table-line(request, dosage, index, size, lang)">
-    <tr class="request-row" th:classappend="${(index == 0)? ' request-first-row' : ''}">
-        <th:block th:if="${index} == 0">
-            <td class="request-common-cell" th:rowspan="${size} * 2"/>
-        </th:block>
+    <tr class="request-row">
         <!-- Nom du médicament -->
         <td>
             [[${request.resolveMedication().resolveMedicationName()}]]
@@ -79,7 +76,7 @@
         </td>
     </tr>
     <tr>
-        <td colspan="8" class="description">
+        <td colspan="7" class="description">
             <th:block th:if="${dosage.period().hasStart() and dosage.period().hasEnd()}">
                 À prendre du
                 <th:block th:insert="~{datatypes :: date-time(${dosage.period().getStartElement()}, ${lang})}"/>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/prescription_fragments.html
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/resources/narrative/templates/prescription_fragments.html
@@ -1,0 +1,101 @@
+<!--
+  ~ This code is made available under the terms of the Eclipse Public License v1.0
+  ~ in the github project https://github.com/project-husky/husky there you also
+  ~ find a list of the contributors and the license information.
+  ~
+  ~ This project has been developed further and modified by the joined working group Husky
+  ~ on the basis of the eHealth Connector opensource project from June 28, 2021,
+  ~ whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+  ~
+  -->
+
+<table th:fragment="table(requests, lang)">
+    <thead>
+    <tr>
+        <td rowspan="2" colspan="2">Nom du médicament</td>
+        <td colspan="4">Dosage</td>
+        <td rowspan="2">Commentaire</td>
+        <td rowspan="2">Voie et localisation</td>
+    </tr>
+    <tr>
+        <td>Matin</td>
+        <td>Midi</td>
+        <td>Soir</td>
+        <td>Nuit</td>
+    </tr>
+    </thead>
+    <tbody class="prescription-body">
+    <th:block th:each="request, index: ${requests}">
+        <th:block th:insert="~{::table-line(${request}, ${request.resolveEffectiveDosageInstructions()}, ${index.index}, ${index.size}, ${lang})}"/>
+    </th:block>
+    </tbody>
+</table>
+
+<th:block th:fragment="table-line(request, dosage, index, size, lang)">
+    <tr class="request-row" th:classappend="${(index == 0)? ' request-first-row' : ''}">
+        <th:block th:if="${index} == 0">
+            <td class="request-common-cell" th:rowspan="${size} * 2"/>
+        </th:block>
+        <!-- Nom du médicament -->
+        <td>
+            [[${request.resolveMedication().resolveMedicationName()}]]
+        </td>
+
+        <!-- Dosage -->
+        <th:block th:if="${dosage.hasIntakes()}">
+            <td th:insert="~{datatypes :: dosage-intake(${dosage.getMornIntake()}, ${lang})}"/>
+            <td th:insert="~{datatypes :: dosage-intake(${dosage.getNoonIntake()}, ${lang})}"/>
+            <td th:insert="~{datatypes :: dosage-intake(${dosage.getEveIntake()}, ${lang})}"/>
+            <td th:insert="~{datatypes :: dosage-intake(${dosage.getNightIntake()}, ${lang})}"/>
+        </th:block>
+        <th:block th:if="${dosage.hasSimpleEventTimings}">
+            <td th:insert="~{datatypes :: intake-timing(${dosage.hasMorningSimpleEventTiming}, ${lang})}"/>
+            <td th:insert="~{datatypes :: intake-timing(${dosage.hasNoonSimpleEventTiming}, ${lang})}"/>
+            <td th:insert="~{datatypes :: intake-timing(${dosage.hasEveningSimpleEventTiming}, ${lang})}"/>
+            <td th:insert="~{datatypes :: intake-timing(${dosage.hasNightSimpleEventTiming}, ${lang})}"/>
+        </th:block>
+        <th:block th:if="${dosage.hasSimpleDose}">
+            <td colspan="4" th:insert="~{datatypes :: simple-dose(${dosage.simpleDose}, ${lang})}"/>
+        </th:block>
+        <th:block th:unless="${dosage.hasIntakes or dosage.hasSimpleEventTimings or dosage.hasSimpleDose}">
+            <td colspan="4" th:text="${dosage.patientInstructions}"/>
+        </th:block>
+
+        <!-- Commentaire (raison et instructions au patient -->
+        <td>
+            <th:block th:if="${dosage.hasIntakes or dosage.hasSimpleEventTimings or dosage.hasSimpleDose}">
+                <th:block th:if="${dosage.hasPatientInstructions()}"
+                          th:text="${dosage.patientInstructions()}"/>
+                <th:block th:if="${dosage.hasPatientInstructions() && request.hasTreatmentReason()}"><br/></th:block>
+            </th:block>
+            <th:block th:if="${request.hasTreatmentReason()}"
+                      th:text="${request.getTreatmentReason()}"/>
+        </td>
+
+        <!-- Voie et localisation -->
+        <td>
+            <th:block th:if="${dosage.hasRouteOfAdministration()}"
+                      th:text="${fopase.getMessage(dosage.routeOfAdministration(), lang)}"/>
+        </td>
+    </tr>
+    <tr>
+        <td colspan="8" class="description">
+            <th:block th:if="${dosage.period().hasStart() and dosage.period().hasEnd()}">
+                À prendre du
+                <th:block th:insert="~{datatypes :: date-time(${dosage.period().getStartElement()}, ${lang})}"/>
+                au
+                <th:block th:insert="~{datatypes :: date-time(${dosage.period().getEndElement()}, ${lang})}"/>
+            </th:block>
+            <th:block th:if="${dosage.period().hasStart() and not dosage.period().hasEnd()}">
+                À prendre dès le
+                <th:block th:insert="~{datatypes :: date-time(${dosage.period().getStartElement()}, ${lang})}"/>
+            </th:block>
+            <th:block th:if="${not dosage.period().hasStart() and dosage.period().hasEnd()}">
+                À prendre jusqu'au
+                <th:block th:insert="~{datatypes :: date-time(${dosage.period().getEndElement()}, ${lang})}"/>
+            </th:block>
+
+            <th:block th:if="${dosage.hasMaxDose()}" th:insert="~{datatypes::max-doses(${dosage}, ${lang})}"/>
+        </td>
+    </tr>
+</th:block>

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedEprDosage.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedEprDosage.java
@@ -171,7 +171,7 @@ public class ChEmedEprDosage extends Dosage {
     public ChEmedEprDosage setRouteOfAdministration(final RouteOfAdministrationEdqm routeOfAdministration) {
         this.getRoute()
                 .getCodingFirstRep()
-                .setSystem(Oids.PREFIX_OID + routeOfAdministration.getCodeSystemId())
+                .setSystem(Oids.PREFIX_OID + Oids.normalize(routeOfAdministration.getCodeSystemId()))
                 .setCode(routeOfAdministration.getCodeValue())
                 .setDisplay(routeOfAdministration.getDisplayName());
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedQuantityWithEmedUnits.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedQuantityWithEmedUnits.java
@@ -34,6 +34,17 @@ public class ChEmedQuantityWithEmedUnits extends SimpleQuantity {
     }
 
     /**
+     * Constructor that pre-populates fields.
+     *
+     * @param quantity the quantity.
+     * @param unitCode the coded form of the unit.
+     */
+    public ChEmedQuantityWithEmedUnits(final BigDecimal quantity, final UnitCode unitCode) {
+        this.setQuantity(quantity);
+        this.setUnitCode(unitCode);
+    }
+
+    /**
      * Resolves the coded form of the unit.
      *
      * @return the coded form of the unit.

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedRangeWithEmedUnits.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedRangeWithEmedUnits.java
@@ -10,6 +10,7 @@
  */
 package org.projecthusky.fhir.emed.ch.epr.datatypes;
 
+import ca.uhn.fhir.model.api.annotation.DatatypeDef;
 import org.hl7.fhir.r4.model.Range;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
@@ -19,6 +20,7 @@ import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
  *
  * @author Ronaldo Loureiro
  **/
+@DatatypeDef(name = "ChEmedRangeWithEmedUnits", isSpecialization = true, profileOf = Range.class)
 public class ChEmedRangeWithEmedUnits extends Range {
 
     /**

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedRatioWithEmedUnits.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedRatioWithEmedUnits.java
@@ -24,12 +24,21 @@ import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
 @DatatypeDef(name = "ChEmedRatioWithEmedUnits", isSpecialization = true, profileOf = Ratio.class)
 public class ChEmedRatioWithEmedUnits extends Ratio {
 
-
     /**
      * Empty constructor for the parser.
      */
     public ChEmedRatioWithEmedUnits() {
         super();
+    }
+
+    /**
+     * Empty constructor for the parser.
+     */
+    public ChEmedRatioWithEmedUnits(final ChEmedQuantityWithEmedUnits numerator,
+                                    final ChEmedQuantityWithEmedUnits denominator) {
+        super();
+        this.setNumerator(numerator);
+        this.setDenominator(denominator);
     }
 
     /**

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedRatioWithEmedUnits.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/datatypes/ChEmedRatioWithEmedUnits.java
@@ -10,6 +10,7 @@
  */
 package org.projecthusky.fhir.emed.ch.epr.datatypes;
 
+import ca.uhn.fhir.model.api.annotation.DatatypeDef;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hl7.fhir.r4.model.Ratio;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
@@ -20,6 +21,7 @@ import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
  *
  * @author Ronaldo Loureiro
  **/
+@DatatypeDef(name = "ChEmedRatioWithEmedUnits", isSpecialization = true, profileOf = Ratio.class)
 public class ChEmedRatioWithEmedUnits extends Ratio {
 
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
@@ -420,7 +420,7 @@ public abstract class ChEmedEprComposition extends Composition {
      * @return this.
      */
     public ChEmedEprComposition setPatient(ChCorePatientEpr chCorePatientEpr) {
-        this.setSubject(References.createReference(chCorePatientEpr));
+        this.setSubject(new Reference(chCorePatientEpr));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
@@ -26,7 +26,6 @@ import org.projecthusky.fhir.emed.ch.common.resource.ChCorePatientEpr;
 import org.projecthusky.fhir.emed.ch.common.resource.ChEmedOrganization;
 import org.projecthusky.fhir.emed.ch.common.util.FhirSystem;
 import org.projecthusky.fhir.emed.ch.epr.resource.extension.ChExtEprDataEnterer;
-import org.projecthusky.fhir.emed.ch.epr.util.References;
 
 import java.time.Instant;
 import java.util.*;
@@ -380,6 +379,30 @@ public abstract class ChEmedEprComposition extends Composition {
                 .setContentType("application/pdf");
         this.getOriginalRepresentationSection().getEntryFirstRep().setResource(binary);
         return this;
+    }
+
+    /**
+     * Returns the annotation section; if missing, it creates it.
+     *
+     * @return the annotation section.
+     */
+    public SectionComponent getAnnotationSection() {
+        var section = getSectionByLoincCode(ANNOTATION_SECTION_CODE_VALUE);
+        if (section == null) {
+            section = this.addSection();
+            section.getCode().addCoding(new Coding(FhirSystem.LOINC,
+                                                   ANNOTATION_SECTION_CODE_VALUE, "Annotation comment [Interpretation] Narrative"));
+            if (EnumConstants.FRENCH_CODE.equals(this.getLanguage())) {
+                section.setTitle("Commentaire");
+            } else if (EnumConstants.GERMAN_CODE.equals(this.getLanguage())) {
+                section.setTitle("Kommentar");
+            } else if (EnumConstants.ITALIAN_CODE.equals(this.getLanguage())) {
+                section.setTitle("Osservazione");
+            } else {
+                section.setTitle("Comment");
+            }
+        }
+        return section;
     }
 
     /**

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
@@ -377,9 +377,8 @@ public abstract class ChEmedEprComposition extends Composition {
     public ChEmedEprComposition setOriginalRepresentationPdf(final byte[] pdfContent) {
         final var binary = new Binary()
                 .setData(pdfContent)
-                .setContentType("application/pdf")
-                .setId("binary-original-representation");
-        this.getOriginalRepresentationSection().addEntry().setResource(binary);
+                .setContentType("application/pdf");
+        this.getOriginalRepresentationSection().getEntryFirstRep().setResource(binary);
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
@@ -16,6 +16,7 @@ import ca.uhn.fhir.model.api.annotation.Extension;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
+import org.projecthusky.common.enums.EnumConstants;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.common.utils.datatypes.Uuids;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
@@ -318,6 +319,16 @@ public abstract class ChEmedEprComposition extends Composition {
             section = this.addSection();
             section.getCode().addCoding(new Coding(FhirSystem.LOINC,
                                                    ORIGINAL_REPR_SECTION_CODE_VALUE, "Clinical presentation Document"));
+            if (EnumConstants.FRENCH_CODE.equals(this.getLanguage())) {
+                this.setTitle("Représentation originale");
+            } else if (EnumConstants.GERMAN_CODE.equals(this.getLanguage())) {
+                this.setTitle("Original Darstellung");
+            } else if (EnumConstants.ITALIAN_CODE.equals(this.getLanguage())) {
+                this.setTitle("Rappresentazione originale");
+            } else {
+                this.setTitle("Original representation");
+            }
+            this.getText().setStatus(Narrative.NarrativeStatus.ADDITIONAL).setDivAsString(this.getTitle());
         }
         return section;
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
@@ -320,15 +320,15 @@ public abstract class ChEmedEprComposition extends Composition {
             section.getCode().addCoding(new Coding(FhirSystem.LOINC,
                                                    ORIGINAL_REPR_SECTION_CODE_VALUE, "Clinical presentation Document"));
             if (EnumConstants.FRENCH_CODE.equals(this.getLanguage())) {
-                this.setTitle("Représentation originale");
+                section.setTitle("Représentation originale");
             } else if (EnumConstants.GERMAN_CODE.equals(this.getLanguage())) {
-                this.setTitle("Original Darstellung");
+                section.setTitle("Original Darstellung");
             } else if (EnumConstants.ITALIAN_CODE.equals(this.getLanguage())) {
-                this.setTitle("Rappresentazione originale");
+                section.setTitle("Rappresentazione originale");
             } else {
-                this.setTitle("Original representation");
+                section.setTitle("Original representation");
             }
-            this.getText().setStatus(Narrative.NarrativeStatus.ADDITIONAL).setDivAsString(this.getTitle());
+            section.getText().setStatus(Narrative.NarrativeStatus.ADDITIONAL).setDivAsString(this.getTitle());
         }
         return section;
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprComposition.java
@@ -369,6 +369,21 @@ public abstract class ChEmedEprComposition extends Composition {
     }
 
     /**
+     * Sets the original representation from the PDF content.
+     *
+     * @param pdfContent The byte content of the PDF representation.
+     * @return the original representation section.
+     */
+    public ChEmedEprComposition setOriginalRepresentationPdf(final byte[] pdfContent) {
+        final var binary = new Binary()
+                .setData(pdfContent)
+                .setContentType("application/pdf")
+                .setId("binary-original-representation");
+        this.getOriginalRepresentationSection().addEntry().setResource(binary);
+        return this;
+    }
+
+    /**
      * Finds a section by its LOINC code or {@code null}, without creating it.
      *
      * @return the section or {@code null}.

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprDocumentAuthorable.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprDocumentAuthorable.java
@@ -41,7 +41,7 @@ public interface ChEmedEprDocumentAuthorable<T> {
      * @return this.
      */
     default T setAuthorDocument(final IBaseResource author) {
-        return setAuthorDocument(References.createReference((Resource) author));
+        return setAuthorDocument(new Reference((Resource) author));
     }
 
     /**

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationDispense.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationDispense.java
@@ -326,7 +326,7 @@ public abstract class ChEmedEprMedicationDispense extends MedicationDispense imp
      * @return this.
      */
     public ChEmedEprMedicationDispense setMedicationReference(final ChEmedEprMedicationDis chEmedEprMedication) {
-        this.setMedication(References.createReference(chEmedEprMedication));
+        this.setMedication(new Reference(chEmedEprMedication));
         this.addContained(chEmedEprMedication);
         return this;
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationIngredient.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationIngredient.java
@@ -75,7 +75,7 @@ public class ChEmedEprMedicationIngredient extends Medication.MedicationIngredie
         this.getItemCodeableConcept()
                 .setText(ingredient.getDisplayName())
                 .getCodingFirstRep()
-                .setSystem(Oids.PREFIX_OID + ingredient.getCodeSystemId())
+                .setSystem(Oids.PREFIX_OID + Oids.normalize(ingredient.getCodeSystemId()))
                 .setCode(ingredient.getCodeValue())
                 .setDisplay(ingredient.getDisplayName());
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
@@ -431,7 +431,7 @@ public abstract class ChEmedEprMedicationRequest extends MedicationRequest imple
     }
 
     public boolean hasTreatmentReason() {
-        return this.reasonCode != null && this.getReasonCodeFirstRep().hasText();
+        return this.hasReasonCode() && !this.getReasonCode().isEmpty() && this.getReasonCodeFirstRep().hasText();
     }
 
     /**
@@ -441,7 +441,7 @@ public abstract class ChEmedEprMedicationRequest extends MedicationRequest imple
      */
     @Nullable
     public String getTreatmentReason() {
-        if (this.reasonCode == null || !this.getReasonCodeFirstRep().hasText()) {
+        if (!this.hasTreatmentReason()) {
             return null;
         }
         return this.getReasonCodeFirstRep().getText();

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
@@ -429,4 +429,21 @@ public abstract class ChEmedEprMedicationRequest extends MedicationRequest imple
     public Instant resolveMedicalAuthorshipTimestamp() {
         return resolveAuthoredOn();
     }
+
+    public boolean hasTreatmentReason() {
+        return this.reasonCode != null && this.getReasonCodeFirstRep().hasText();
+    }
+
+    /**
+     * Gets the treatment reason if available.
+     *
+     * @return the treatment reason or {@code null}.
+     */
+    @Nullable
+    public String getTreatmentReason() {
+        if (this.reasonCode == null || !this.getReasonCodeFirstRep().hasText()) {
+            return null;
+        }
+        return this.getReasonCodeFirstRep().getText();
+    }
 }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
@@ -44,7 +44,6 @@ public abstract class ChEmedEprMedicationRequest extends MedicationRequest imple
      */
     public ChEmedEprMedicationRequest() {
         super();
-        this.setStatus(MedicationRequestStatus.COMPLETED);
         this.setIntent(MedicationRequestIntent.ORDER);
     }
 
@@ -55,7 +54,6 @@ public abstract class ChEmedEprMedicationRequest extends MedicationRequest imple
      */
     public ChEmedEprMedicationRequest(final UUID entryUuid) {
         super();
-        this.setStatus(MedicationRequestStatus.COMPLETED);
         this.setIntent(MedicationRequestIntent.ORDER);
         this.addIdentifier().setValue(Uuids.URN_PREFIX + entryUuid).setSystem(FhirSystem.URI);
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationRequest.java
@@ -6,6 +6,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hl7.fhir.r4.model.Dosage;
 import org.hl7.fhir.r4.model.Identifier;
 import org.hl7.fhir.r4.model.MedicationRequest;
+import org.hl7.fhir.r4.model.Reference;
 import org.projecthusky.common.utils.datatypes.Uuids;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.enums.EmedEntryType;
@@ -213,7 +214,7 @@ public abstract class ChEmedEprMedicationRequest extends MedicationRequest imple
      * @return this.
      */
     public ChEmedEprMedicationRequest setMedicationReference(final ChEmedEprMedication chEmedEprMedication) {
-        this.setMedication(References.createReference(chEmedEprMedication));
+        this.setMedication(new Reference(chEmedEprMedication));
         return this;
     }
 
@@ -224,7 +225,7 @@ public abstract class ChEmedEprMedicationRequest extends MedicationRequest imple
      * @return this.
      */
     public ChEmedEprMedicationRequest setPatient(final ChCorePatientEpr chCorePatientEpr) {
-        this.setSubject(References.createReference(chCorePatientEpr));
+        this.setSubject(new Reference(chCorePatientEpr));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationStatement.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationStatement.java
@@ -165,7 +165,7 @@ public abstract class ChEmedEprMedicationStatement extends MedicationStatement i
     }
 
     public boolean hasTreatmentReason() {
-        return this.reasonCode != null && this.getReasonCodeFirstRep().hasText();
+        return this.hasReasonCode() && !this.getReasonCode().isEmpty() && this.getReasonCodeFirstRep().hasText();
     }
 
     /**
@@ -175,7 +175,7 @@ public abstract class ChEmedEprMedicationStatement extends MedicationStatement i
      */
     @Nullable
     public String getTreatmentReason() {
-        if (this.reasonCode == null || !this.getReasonCodeFirstRep().hasText()) {
+        if (!this.hasTreatmentReason()) {
             return null;
         }
         return this.getReasonCodeFirstRep().getText();

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationStatement.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprMedicationStatement.java
@@ -392,7 +392,7 @@ public abstract class ChEmedEprMedicationStatement extends MedicationStatement i
      */
     @ExpectsValidResource
     public Instant resolveAsserted() {
-        if (this.getDateAssertedElement() == null)
+        if (!this.hasDateAsserted())
             throw new InvalidEmedContentException("The asserted timestamp is missing");
         return this.getDateAssertedElement().getValueAsCalendar().toInstant();
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprObservation.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprObservation.java
@@ -373,7 +373,7 @@ public abstract class ChEmedEprObservation<T extends ChEmedEprMedicationStatemen
      * @return this.
      */
     public ChEmedEprObservation<T> setMedicationStatementChanged(final ChEmedEprMedicationStatementMtp medicationStatement) {
-        this.medicationStatementChanged = References.createReference(medicationStatement);
+        this.medicationStatementChanged = new Reference(medicationStatement);
         return this;
     }
 
@@ -384,7 +384,7 @@ public abstract class ChEmedEprObservation<T extends ChEmedEprMedicationStatemen
      * @return this.
      */
     public ChEmedEprObservation<T> setMedicationRequestChanged(final ChEmedEprMedicationRequestPre medicationRequest) {
-        this.medicationRequestChanged = References.createReference(medicationRequest);
+        this.medicationRequestChanged = new Reference(medicationRequest);
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprPractitioner.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprPractitioner.java
@@ -61,7 +61,7 @@ public class ChEmedEprPractitioner extends Practitioner {
     public Identifier setGln(final String gln) {
         var identifier = Identifiers.getBySystem(this.getIdentifier(), FhirSystem.GLN);
         if (identifier == null) {
-            identifier = new Identifier();
+            identifier = this.addIdentifier();
             identifier.setSystem(FhirSystem.GLN);
         }
         identifier.setValue(gln);

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
@@ -12,6 +12,7 @@ package org.projecthusky.fhir.emed.ch.epr.resource.dis;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import org.hl7.fhir.r4.model.*;
+import org.projecthusky.common.enums.EnumConstants;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
@@ -70,6 +71,16 @@ public class ChEmedEprCompositionDis extends ChEmedEprComposition {
             section.getCode().addCoding(new Coding(FhirSystem.LOINC,
                                                    DISPENSE_SECTION_CODE_VALUE,
                                                    "Medication dispensed.brief Document"));
+            if (EnumConstants.FRENCH_CODE.equals(this.getLanguage())) {
+                section.setTitle("Dispensation d'un médicament");
+            } else if (EnumConstants.GERMAN_CODE.equals(this.getLanguage())) {
+                section.setTitle("Abgabe eines Medikaments");
+            } else if (EnumConstants.ITALIAN_CODE.equals(this.getLanguage())) {
+                section.setTitle("Dispensazione di un medicamento");
+            } else {
+                section.setTitle("Medication dispensed");
+            }
+            section.getText().setStatus(Narrative.NarrativeStatus.ADDITIONAL).setDivAsString(section.getTitle());
         }
         return section;
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
@@ -54,7 +54,8 @@ public class ChEmedEprCompositionDis extends ChEmedEprComposition {
         super(compositionId, date, language);
         this.getType().addCoding(new Coding(FhirSystem.SNOMEDCT,
                                             "82291000195104",
-                                            "Medication dispense document (record artifact)"));
+                                            "Medication dispense document (record artifact)")
+                                         .setVersion("http://snomed.info/sct/2011000195101"));
         this.getType().addCoding(new Coding(FhirSystem.LOINC, "60593-1", "Medication dispensed.extended Document"));
         this.setTitle(CompositionTitle.DIS.getDisplayName(language));
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
@@ -53,7 +53,7 @@ public class ChEmedEprCompositionDis extends ChEmedEprComposition {
                                    final LanguageCode language) {
         super(compositionId, date, language);
         this.getType().addCoding(new Coding(FhirSystem.SNOMEDCT,
-                                            "294121000195110",
+                                            "82291000195104",
                                             "Medication dispense document (record artifact)"));
         this.getType().addCoding(new Coding(FhirSystem.LOINC, "60593-1", "Medication dispensed.extended Document"));
         this.setTitle(CompositionTitle.DIS.getDisplayName(language));

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
@@ -11,10 +11,7 @@
 package org.projecthusky.fhir.emed.ch.epr.resource.dis;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Device;
-import org.hl7.fhir.r4.model.DomainResource;
-import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.*;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
@@ -182,7 +179,7 @@ public class ChEmedEprCompositionDis extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionDis addAuthor(final ChEmedEprPractitionerRole author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -193,7 +190,7 @@ public class ChEmedEprCompositionDis extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionDis addAuthor(final ChCorePatientEpr author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -205,7 +202,7 @@ public class ChEmedEprCompositionDis extends ChEmedEprComposition {
      */
     public ChEmedEprCompositionDis setMedicationDispense(final ChEmedEprMedicationDispenseDis medicationDispense) {
         final var entry = this.getDispenseSection().getEntry();
-        final var reference = References.createReference(medicationDispense);
+        final var reference = new Reference(medicationDispense);
         if (entry.isEmpty()) {
             entry.add(reference);
         } else {

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/dis/ChEmedEprCompositionDis.java
@@ -20,7 +20,6 @@ import org.projecthusky.fhir.emed.ch.common.util.FhirSystem;
 import org.projecthusky.fhir.emed.ch.epr.enums.CompositionTitle;
 import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprComposition;
 import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprPractitionerRole;
-import org.projecthusky.fhir.emed.ch.epr.util.References;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -137,21 +136,6 @@ public class ChEmedEprCompositionDis extends ChEmedEprComposition {
                 .filter(author -> author instanceof ChEmedEprPractitionerRole || author instanceof ChCorePatientEpr)
                 .findFirst()
                 .orElseThrow(() -> new InvalidEmedContentException(""));
-    }
-
-    /**
-     * Returns the annotation section; if missing, it creates it.
-     *
-     * @return the annotation section.
-     */
-    public SectionComponent getAnnotationSection() {
-        var section = getSectionByLoincCode(ANNOTATION_SECTION_CODE_VALUE);
-        if (section == null) {
-            section = this.addSection();
-            section.getCode().addCoding(new Coding(FhirSystem.LOINC,
-                                                   ANNOTATION_SECTION_CODE_VALUE, "Annotation comment [Interpretation] Narrative"));
-        }
-        return section;
     }
 
     /**

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/mtp/ChEmedEprCompositionMtp.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/mtp/ChEmedEprCompositionMtp.java
@@ -11,10 +11,7 @@
 package org.projecthusky.fhir.emed.ch.epr.resource.mtp;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Device;
-import org.hl7.fhir.r4.model.DomainResource;
-import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.*;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
@@ -185,7 +182,7 @@ public class ChEmedEprCompositionMtp extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionMtp addAuthor(final ChEmedEprPractitionerRole author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -196,7 +193,7 @@ public class ChEmedEprCompositionMtp extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionMtp addAuthor(final ChCorePatientEpr author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -207,7 +204,7 @@ public class ChEmedEprCompositionMtp extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionMtp addAuthor(final Device author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -219,7 +216,7 @@ public class ChEmedEprCompositionMtp extends ChEmedEprComposition {
      */
     public ChEmedEprCompositionMtp setMedicationStatement(final ChEmedEprMedicationStatementMtp medicationStatement) {
         final var entry = this.getTreatmentPlanSection().getEntry();
-        final var reference = References.createReference(medicationStatement);
+        final var reference = new Reference(medicationStatement);
         if (entry.isEmpty()) {
             entry.add(reference);
         } else {

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/mtp/ChEmedEprCompositionMtp.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/mtp/ChEmedEprCompositionMtp.java
@@ -161,21 +161,6 @@ public class ChEmedEprCompositionMtp extends ChEmedEprComposition {
     }
 
     /**
-     * Returns the annotation section; if missing, it creates it.
-     *
-     * @return the annotation section.
-     */
-    public SectionComponent getAnnotationSection() {
-        var section = getSectionByLoincCode(ANNOTATION_SECTION_CODE_VALUE);
-        if (section == null) {
-            section = this.addSection();
-            section.getCode().addCoding(new Coding(FhirSystem.LOINC,
-                                                   ANNOTATION_SECTION_CODE_VALUE, "Annotation comment [Interpretation] Narrative"));
-        }
-        return section;
-    }
-
-    /**
      * Adds a {@link ChEmedEprPractitionerRole} to the list of document authors.
      *
      * @param author the author od the document.

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/padv/ChEmedEprCompositionPadv.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/padv/ChEmedEprCompositionPadv.java
@@ -11,10 +11,7 @@
 package org.projecthusky.fhir.emed.ch.epr.resource.padv;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Device;
-import org.hl7.fhir.r4.model.DomainResource;
-import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.*;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
@@ -182,7 +179,7 @@ public class ChEmedEprCompositionPadv extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionPadv addAuthor(final ChEmedEprPractitionerRole author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -193,7 +190,7 @@ public class ChEmedEprCompositionPadv extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionPadv addAuthor(final ChCorePatientEpr author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/padv/ChEmedEprCompositionPadv.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/padv/ChEmedEprCompositionPadv.java
@@ -140,21 +140,6 @@ public class ChEmedEprCompositionPadv extends ChEmedEprComposition {
     }
 
     /**
-     * Returns the annotation section; if missing, it creates it.
-     *
-     * @return the annotation section.
-     */
-    public SectionComponent getAnnotationSection() {
-        var section = getSectionByLoincCode(ANNOTATION_SECTION_CODE_VALUE);
-        if (section == null) {
-            section = this.addSection();
-            section.getCode().addCoding(new Coding(FhirSystem.LOINC,
-                                                   ANNOTATION_SECTION_CODE_VALUE, "Annotation comment [Interpretation] Narrative"));
-        }
-        return section;
-    }
-
-    /**
      * Returns whether the pharmaceutical advice section exists.
      *
      * @return {@code true} if the pharmaceutical advice section exists, {@code false} otherwise.

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprCompositionPml.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprCompositionPml.java
@@ -92,22 +92,6 @@ public class ChEmedEprCompositionPml extends ChEmedEprComposition {
     }
 
     /**
-     * Returns the annotation section; if missing, it creates it.
-     *
-     * @return the annotation section.
-     */
-    public SectionComponent getAnnotationSection() {
-        var section = getSectionByLoincCode(ANNOTATION_SECTION_CODE_VALUE);
-        if (section == null) {
-            section = this.addSection();
-            section.getCode().addCoding(new Coding(FhirSystem.LOINC,
-                                                   ANNOTATION_SECTION_CODE_VALUE, "Annotation comment"));
-            section.setTitle("Comment");
-        }
-        return section;
-    }
-
-    /**
      * Returns the list with medication statement, medication request, medication dispense and observation.
      *
      * @return the list with medication statement, medication request, medication dispense and observation

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprCompositionPml.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprCompositionPml.java
@@ -155,7 +155,7 @@ public class ChEmedEprCompositionPml extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionPml addAuthor(final Device author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprMedicationDispensePml.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprMedicationDispensePml.java
@@ -109,7 +109,7 @@ public class ChEmedEprMedicationDispensePml
      * @return this.
      */
     public ChEmedEprMedicationDispensePml setPerformer(final ChEmedEprPractitionerRole actor) {
-        this.getPerformerFirstRep().setActor(References.createReference(actor));
+        this.getPerformerFirstRep().setActor(new Reference(actor));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprObservationPml.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pml/ChEmedEprObservationPml.java
@@ -102,7 +102,7 @@ public class ChEmedEprObservationPml
      * @return this.
      */
     public ChEmedEprObservationPml setPerformer(final ChEmedEprPractitionerRole performer) {
-        final var reference = References.createReference(performer);
+        final var reference = new Reference(performer);
         if (this.getPerformer().isEmpty()) {
             this.addPerformer(reference);
         } else {
@@ -118,7 +118,7 @@ public class ChEmedEprObservationPml
      * @return this.
      */
     public ChEmedEprObservationPml setPerformer(final ChCorePatientEpr performer) {
-        final var reference = References.createReference(performer);
+        final var reference = new Reference(performer);
         if (this.getPerformer().isEmpty()) {
             this.addPerformer(reference);
         } else {
@@ -134,7 +134,7 @@ public class ChEmedEprObservationPml
      * @return this.
      */
     public ChEmedEprObservationPml setPerformer(final RelatedPerson performer) {
-        final var reference = References.createReference(performer);
+        final var reference = new Reference(performer);
         if (this.getPerformer().isEmpty()) {
             this.addPerformer(reference);
         } else {

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pmlc/ChEmedEprCompositionPmlc.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pmlc/ChEmedEprCompositionPmlc.java
@@ -13,13 +13,13 @@ package org.projecthusky.fhir.emed.ch.epr.resource.pmlc;
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Device;
+import org.hl7.fhir.r4.model.Reference;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
 import org.projecthusky.fhir.emed.ch.common.util.FhirSystem;
 import org.projecthusky.fhir.emed.ch.epr.enums.CompositionTitle;
 import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprComposition;
-import org.projecthusky.fhir.emed.ch.epr.util.References;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -170,7 +170,7 @@ public class ChEmedEprCompositionPmlc extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionPmlc addAuthor(final Device author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pmlc/ChEmedEprCompositionPmlc.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pmlc/ChEmedEprCompositionPmlc.java
@@ -73,22 +73,6 @@ public class ChEmedEprCompositionPmlc extends ChEmedEprComposition {
     }
 
     /**
-     * Returns the annotation section; if missing, it creates it.
-     *
-     * @return the annotation section.
-     */
-    public SectionComponent getAnnotationSection() {
-        var section = getSectionByLoincCode(ANNOTATION_SECTION_CODE_VALUE);
-        if (section == null) {
-            section = this.addSection();
-            section.getCode().addCoding(new Coding(FhirSystem.LOINC,
-                                                   ANNOTATION_SECTION_CODE_VALUE, "Annotation comment [Interpretation] Narrative"));
-            section.setTitle("Comment");
-        }
-        return section;
-    }
-
-    /**
      * Returns the card section; if missing, it creates it.
      *
      * @return the card section.

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
@@ -157,21 +157,6 @@ public class ChEmedEprCompositionPre extends ChEmedEprComposition {
     }
 
     /**
-     * Returns the annotation section; if missing, it creates it.
-     *
-     * @return the annotation section.
-     */
-    public SectionComponent getAnnotationSection() {
-        var section = getSectionByLoincCode(ANNOTATION_SECTION_CODE_VALUE);
-        if (section == null) {
-            section = this.addSection();
-            section.getCode().addCoding(new Coding(FhirSystem.LOINC,
-                                                   ANNOTATION_SECTION_CODE_VALUE, "Annotation comment [Interpretation] Narrative"));
-        }
-        return section;
-    }
-
-    /**
      * Returns whether the prescription section exists.
      *
      * @return {@code true} if the prescription section exists, {@code false} otherwise.

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
@@ -15,6 +15,7 @@ import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Device;
 import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Resource;
+import org.projecthusky.common.enums.EnumConstants;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
 import org.projecthusky.fhir.emed.ch.common.error.InvalidEmedContentException;
@@ -121,6 +122,15 @@ public class ChEmedEprCompositionPre extends ChEmedEprComposition {
             section.getCode().addCoding(new Coding(FhirSystem.LOINC,
                                                    PRESCRIPTION_SECTION_CODE_VALUE,
                                                    "Prescription list"));
+            if (EnumConstants.FRENCH_CODE.equals(this.getLanguage())) {
+                section.setTitle("Prescription médicamenteuse");
+            } else if (EnumConstants.GERMAN_CODE.equals(this.getLanguage())) {
+                section.setTitle("Arzneimittelverordnung");
+            } else if (EnumConstants.ITALIAN_CODE.equals(this.getLanguage())) {
+                section.setTitle("Prescrizione di droga");
+            } else {
+                section.setTitle("Prescription for medication");
+            }
         }
         return section;
     }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
@@ -211,13 +211,7 @@ public class ChEmedEprCompositionPre extends ChEmedEprComposition {
      * @param medicationRequest the medication request.
      */
     public ChEmedEprCompositionPre addMedicationRequest(final ChEmedEprMedicationRequestPre medicationRequest) {
-        final var entry = this.getPrescriptionSection().getEntry();
-        final var reference = References.createReference(medicationRequest);
-        if (entry.isEmpty()) {
-            entry.add(reference);
-        } else {
-            entry.set(0, reference);
-        }
+        this.getPrescriptionSection().getEntry().add(References.createReference(medicationRequest));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprCompositionPre.java
@@ -11,10 +11,7 @@
 package org.projecthusky.fhir.emed.ch.epr.resource.pre;
 
 import ca.uhn.fhir.model.api.annotation.ResourceDef;
-import org.hl7.fhir.r4.model.Coding;
-import org.hl7.fhir.r4.model.Device;
-import org.hl7.fhir.r4.model.DomainResource;
-import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.*;
 import org.projecthusky.common.enums.EnumConstants;
 import org.projecthusky.common.enums.LanguageCode;
 import org.projecthusky.fhir.emed.ch.common.annotation.ExpectsValidResource;
@@ -24,7 +21,6 @@ import org.projecthusky.fhir.emed.ch.common.util.FhirSystem;
 import org.projecthusky.fhir.emed.ch.epr.enums.CompositionTitle;
 import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprComposition;
 import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprPractitionerRole;
-import org.projecthusky.fhir.emed.ch.epr.util.References;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -200,7 +196,7 @@ public class ChEmedEprCompositionPre extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionPre addAuthor(final ChEmedEprPractitionerRole author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -211,7 +207,7 @@ public class ChEmedEprCompositionPre extends ChEmedEprComposition {
      * @return this.
      */
     public ChEmedEprCompositionPre addAuthor(final ChCorePatientEpr author) {
-        this.addAuthor(References.createReference(author));
+        this.addAuthor(new Reference(author));
         return this;
     }
 
@@ -221,7 +217,7 @@ public class ChEmedEprCompositionPre extends ChEmedEprComposition {
      * @param medicationRequest the medication request.
      */
     public ChEmedEprCompositionPre addMedicationRequest(final ChEmedEprMedicationRequestPre medicationRequest) {
-        this.getPrescriptionSection().getEntry().add(References.createReference(medicationRequest));
+        this.getPrescriptionSection().getEntry().add(new Reference(medicationRequest));
         return this;
     }
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprMedicationRequestPre.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/pre/ChEmedEprMedicationRequestPre.java
@@ -18,6 +18,7 @@ public class ChEmedEprMedicationRequestPre extends ChEmedEprMedicationRequest {
      */
     public ChEmedEprMedicationRequestPre() {
         super();
+        this.setStatus(MedicationRequestStatus.ACTIVE);
     }
 
     /**
@@ -27,6 +28,7 @@ public class ChEmedEprMedicationRequestPre extends ChEmedEprMedicationRequest {
      */
     public ChEmedEprMedicationRequestPre(final UUID entryUuid) {
         super(entryUuid);
+        this.setStatus(MedicationRequestStatus.ACTIVE);
     }
 
     @Override

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/util/References.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/util/References.java
@@ -27,7 +27,9 @@ public class References {
      *
      * @param resource The {@link Resource} resource.
      * @return the reference
+     * @deprecated Use {@link Reference#Reference(IAnyResource)} directly instead.
      */
+    @Deprecated(forRemoval = true, since = "2024-04-19")
     public static Reference createReference(final Resource resource) {
         final var reference = new Reference();
         reference.setResource(resource);

--- a/pom.xml
+++ b/pom.xml
@@ -529,7 +529,7 @@
 			<dependency>
 				<groupId>org.projectlombok</groupId>
 				<artifactId>lombok</artifactId>
-				<version>1.18.26</version>
+				<version>1.18.32</version>
 				<scope>provided</scope>
 			</dependency>
 			<!-- Own modules -->


### PR DESCRIPTION
- Fix various issues in the HAPI classes
- Implement various improvements
- Add support for prescription document in the HTML narrative generator

Note: this PR is rebased on top of #116 

@dvribeira : the patient gender is now shown, it will appear in the medication card too. And there's Thymeleaf fragments to display a PractitionerRole/Practitioner/Organization now.

Example of generated prescription PDF: 
[c8679e23-ee8e-433a-be28-4c810f535c94.pdf](https://github.com/project-husky/husky/files/15151155/c8679e23-ee8e-433a-be28-4c810f535c94.pdf)
