### PR TITLE
Common: Fixes time zone handling in DateTimes

### DIFF
--- a/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Author.java
+++ b/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Author.java
@@ -20,6 +20,7 @@ import org.projecthusky.common.utils.time.DateTimes;
 import org.projecthusky.common.utils.time.Hl7Dtm;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.*;
 
 /**
@@ -49,7 +50,7 @@ public class Author {
         Date dateTime = getTimeAsDate();
 
 		if (dateTime != null) {
-			mAuthor.setTime(DateTimes.toDateTs(dateTime.toInstant()));
+			mAuthor.setTime(DateTimes.toDateTs(dateTime.toInstant(), ZoneId.systemDefault()));
 		}
 
         setTime(null);
@@ -126,7 +127,7 @@ public class Author {
 		Date dateTime = getTimeAsDate();
 
 		if (dateTime != null) {
-			mAuthor.setTime(DateTimes.toDateTs(dateTime.toInstant()));
+			mAuthor.setTime(DateTimes.toDateTs(dateTime.toInstant(), ZoneId.systemDefault()));
 		}
 
         setTime(null);
@@ -656,7 +657,7 @@ public class Author {
 		if (date != null) {
 			mAuthor.setTime(DateTimes.toDateTs(date.toInstant(), date.getTimeZone().toZoneId()));
         } else {
-			mAuthor.setTime(DateTimes.toDateTs(new Date().toInstant()));
+			mAuthor.setTime(DateTimes.toDateTs(new Date().toInstant(), ZoneId.systemDefault()));
         }
     }
 

--- a/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Participant.java
+++ b/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Participant.java
@@ -18,6 +18,7 @@ import org.projecthusky.common.utils.time.DateTimes;
 import org.projecthusky.common.utils.time.Hl7Dtm;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -113,7 +114,7 @@ public class Participant {
 		if (date == null) {
 			mParticipant.setTime(new IVLTS(NullFlavor.UNKNOWN_L1));
 		} else {
-			mParticipant.setTime(new IVLTS(DateTimes.toHl7Dtm(date.toInstant())));
+			mParticipant.setTime(new IVLTS(DateTimes.toHl7Dtm(date.toInstant(), ZoneId.systemDefault())));
 		}
     }
 

--- a/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Patient.java
+++ b/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Patient.java
@@ -14,6 +14,7 @@ package org.projecthusky.common.model;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -297,7 +298,7 @@ public class Patient extends Person {
      * @param birthDay the new birthday
      */
     public void setBirthday(ZonedDateTime birthDay) {
-		mPatient.setBirthTime(DateTimes.toDateTs(birthDay));
+		mPatient.setBirthTime(DateTimes.toDateTs(birthDay, birthDay.getZone()));
     }
 
     /**

--- a/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Performer.java
+++ b/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/model/Performer.java
@@ -17,6 +17,7 @@ import org.projecthusky.common.enums.NullFlavor;
 import org.projecthusky.common.hl7cdar2.*;
 import org.projecthusky.common.utils.time.DateTimes;
 
+import java.time.ZoneId;
 import java.util.*;
 
 /**
@@ -343,7 +344,7 @@ public class Performer {
 		if (eurDate == null) {
 			mPerfomer.setTime(new IVLTS(NullFlavor.UNKNOWN_L1));
 		} else {
-			mPerfomer.setTime(new IVLTS(DateTimes.toHl7Dtm(eurDate.toInstant())));
+			mPerfomer.setTime(new IVLTS(DateTimes.toHl7Dtm(eurDate.toInstant(), ZoneId.systemDefault())));
 		}
     }
 

--- a/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/utils/time/DateTimes.java
+++ b/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/utils/time/DateTimes.java
@@ -38,12 +38,14 @@ public final class DateTimes {
      */
     private static final DateTimeFormatter TS_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssZ")
         .withZone(ZoneId.systemDefault());
+    private static final String TS_DATETIME_FORMAT = "yyyyMMddHHmmssZ";
 
     /**
      * The TS.CH.TZ (TS) date format.
      */
     private static final DateTimeFormatter TS_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
         .withZone(ZoneId.systemDefault());
+    private static final String TS_DATE_FORMAT = "yyyyMMdd";
 
     /**
      * This class is not instantiable.
@@ -228,21 +230,49 @@ public final class DateTimes {
      *
      * @param instant The instant to convert.
      * @return the equivalent zoned date time.
+     * @deprecated use {@link DateTimes#getZonedDateTime(Instant, ZoneId)} instead, to control the time zone.
      */
     @NonNull
+    @Deprecated(since = "2024-08-23", forRemoval = true)
     public static ZonedDateTime getZonedDateTime(@NonNull final Instant instant) {
         return ZonedDateTime.ofInstant(instant, ZoneId.of("Europe/Zurich"));
     }
 
     /**
-     * Formats an {@link Instant} to an HL7 DTM. UTC is assumed.
+     * Converts an {@link Instant} to a {@link ZonedDateTime}.
+     *
+     * @param instant The instant to convert.
+     * @param zone    The time zone to use.
+     * @return the equivalent zoned date time.
+     */
+    @NonNull
+    public static ZonedDateTime getZonedDateTime(@NonNull final Instant instant, @NonNull final ZoneId zone) {
+        return ZonedDateTime.ofInstant(instant, zone);
+    }
+
+    /**
+     * Formats an {@link Instant} to an HL7 DTM. Local time zone is assumed.
      *
      * @param instant The instant to convert.
      * @return the resulting HL7 DTM.
+     * @deprecated use {@link DateTimes#toHl7Dtm(Instant, ZoneId)} instead, to control the time zone.
      */
     @NonNull
+    @Deprecated(since = "2024-08-23", forRemoval = true)
     public static String toHl7Dtm(@NonNull final Instant instant) {
         return HL7_DATETIME_FORMATTER.format(instant);
+    }
+
+    /**
+     * Formats an {@link Instant} to an HL7 DTM.
+     *
+     * @param instant The instant to convert.
+     * @param zone    The time zone to use.
+     * @return the resulting HL7 DTM.
+     */
+    @NonNull
+    public static String toHl7Dtm(@NonNull final Instant instant, @NonNull final ZoneId zone) {
+        return DateTimeFormatter.ofPattern(TS_DATETIME_FORMAT).withZone(zone).format(instant);
     }
 
     /**
@@ -251,11 +281,27 @@ public final class DateTimes {
      *
      * @param temporal The temporal object to convert.
      * @return the resulting timestamp.
+     * @deprecated use {@link DateTimes#toDatetimeTs(TemporalAccessor, ZoneId)} instead, to control the time zone.
      */
     @NonNull
+    @Deprecated(since = "2024-08-23", forRemoval = true)
     public static TS toDatetimeTs(@NonNull final TemporalAccessor temporal) {
         final TS ts = new TS();
         ts.setValue(TS_DATETIME_FORMATTER.format(temporal));
+        return ts;
+    }
+
+    /**
+     * Converts an {@link Instant} to a {@link TS} (TS.CH.TZ, Time Stamp) with a precision to the second.
+     *
+     * @param temporal The temporal object to convert.
+     * @param zone     The time zone to use.
+     * @return the resulting timestamp.
+     */
+    @NonNull
+    public static TS toDatetimeTs(@NonNull final TemporalAccessor temporal, @NonNull final ZoneId zone) {
+        final TS ts = new TS();
+        ts.setValue(DateTimeFormatter.ofPattern(TS_DATETIME_FORMAT).withZone(zone).format(temporal));
         return ts;
     }
 
@@ -264,8 +310,10 @@ public final class DateTimes {
      *
      * @param temporal The temporal object to convert.
      * @return the resulting timestamp.
+     * @deprecated use {@link DateTimes#toDateTs(TemporalAccessor, ZoneId)} instead, to control the time zone.
      */
     @NonNull
+    @Deprecated(since = "2024-08-23", forRemoval = true)
     public static TS toDateTs(@NonNull final TemporalAccessor temporal) {
         final TS ts = new TS();
         ts.setValue(TS_DATE_FORMATTER.format(temporal));
@@ -283,7 +331,7 @@ public final class DateTimes {
 	@NonNull
 	public static TS toDateTs(@NonNull final TemporalAccessor temporal, ZoneId zone) {
 		final TS ts = new TS();
-		ts.setValue(DateTimeFormatter.ofPattern("yyyyMMdd").withZone(zone).format(temporal));
+		ts.setValue(DateTimeFormatter.ofPattern(TS_DATE_FORMAT).withZone(zone).format(temporal));
 		return ts;
 	}
 

--- a/husky-communication/husky-service/src/test/java/org/projecthusky/communication/requests/pdq/PdqSearchQueryTest.java
+++ b/husky-communication/husky-service/src/test/java/org/projecthusky/communication/requests/pdq/PdqSearchQueryTest.java
@@ -1,0 +1,40 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ *
+ */
+package org.projecthusky.communication.requests.pdq;
+
+import org.junit.jupiter.api.Test;
+import org.projecthusky.common.communication.Destination;
+import org.projecthusky.common.model.Identificator;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link PdqSearchQuery}.
+ *
+ * @author Quentin Ligier
+ **/
+class PdqSearchQueryTest {
+
+    @Test
+    void testBuild() throws URISyntaxException {
+        final var destination = new Destination("4.5.6", new URI("http://www.example.org"));
+        destination.setReceiverFacilityOid("7.8.9");
+        final var query = PdqSearchQuery.builder()
+                .destination(destination)
+                .identificator(new Identificator("1.2.3", "ABC"))
+                .build();
+        final var prpa = query.build().getRootElement();
+        System.out.println(prpa);
+    }
+}


### PR DESCRIPTION
Issue: #164

This PR:

1. Deprecates methods that are badly handling time zones (no indication of the time zone used, or wrongly documented as UTC).
2. Adds new methods that take the time zone as input.
3. Fixes usage of these methods in the common parts.

I've not touched the Austrian code (`husky-common-at`, `husky-elga`), it would require a review to ensure the local time zone (or UTC) is to be used.