### PR TITLE
229 compiling bugs on develop 2x after merging med

### DIFF
--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-common/src/main/java/org/projecthusky/fhir/emed/ch/common/enums/AddressLineType.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-common/src/main/java/org/projecthusky/fhir/emed/ch/common/enums/AddressLineType.java
@@ -221,6 +221,18 @@ public enum AddressLineType implements ValueSetEnumInterface, FhirValueSetEnumIn
         return new CodeableConcept().setText(this.displayNames[0]).addCoding(this.getCoding());
     }
 
+    @Override
+    public @NonNull Coding getCoding(LanguageCode languageCode) {
+        return new Coding(this.getFhirSystem(),
+                this.getCodeValue(),
+                this.getDisplayName(languageCode));
+    }
+
+    @Override
+    public @NonNull CodeableConcept getCodeableConcept(LanguageCode languageCode) {
+        return new CodeableConcept().setText(this.getDisplayName(languageCode)).addCoding(this.getCoding(languageCode));
+    }
+
     /**
      * Compares the enum value to the given FHIR Coding.
      *

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprObservation.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/resource/ChEmedEprObservation.java
@@ -441,7 +441,7 @@ public abstract class ChEmedEprObservation<S extends ChEmedEprMedicationStatemen
      * @param languageCode  the requested language for the display name.
      * @return this.
      */
-    public ChEmedEprObservation<T> setPadvEntryType(final EmedPadvEntryType padvEntryType,
+    public ChEmedEprObservation<S, R> setPadvEntryType(final EmedPadvEntryType padvEntryType,
                                                     final LanguageCode languageCode) {
         this.setCode(padvEntryType.getCodeableConcept(languageCode));
         return this;


### PR DESCRIPTION
Closes #229 

This PR fixes the two following issues:

- AddressLineType enum was added in a branch that didn't had the latest changes to FhirValueSetEnumInterface hance it missed the language specific versions for getCoding and getCodeableConcept.
- Somehow the signature ChEmedEprObservation#setPadvEntryType was not up to date (generic parameters not up to date with the rest of the class).