### PR TITLE
Ch emed epr/248 offer hapi based validator

### DIFF
--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprHapiValidator.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprHapiValidator.java
@@ -1,0 +1,99 @@
+package org.projecthusky.fhir.emed.ch.epr.validator;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.ValidationOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hl7.fhir.common.hapi.validation.support.*;
+import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprDocument;
+import org.projecthusky.fhir.emed.ch.epr.validator.logicvalidator.LogicValidator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * A HAPI based implementation of the {@link ChEmedEprValidator}.
+ */
+@Slf4j
+public class ChEmedEprHapiValidator implements ChEmedEprValidator{
+    final private FhirValidator validator;
+    final private LogicValidator logicValidator = new LogicValidator();
+
+    /**
+     * Creates an instance of an <i>offline</i> {@link ChEmedEprValidator}, that is, a validator that will not try to
+     * use external terminology services, and that uses HAPI's validation engine.
+     *
+     * @param context The FHIR context to be used.
+     * @throws IOException if the NPM packages can't be found in the classpath.
+     */
+    public ChEmedEprHapiValidator(final FhirContext context) throws IOException {
+        this(context, null);
+    }
+
+    /**
+     * Creates an instance of a HAPI based {@link ChEmedEprValidator}.
+     * @param context  The FHIR context to be used.
+     * @param txServer The URL of the terminology server to be used. If {@code null} or blank, no external terminology
+     *                 services will be used for validation.
+     * @throws IOException if the NPM packages can't be found in the classpath.
+     */
+    public ChEmedEprHapiValidator(final FhirContext context, final @Nullable String txServer)  throws IOException {
+        final var packageSupport = new NpmPackageValidationSupport(context);
+        for (var packageResource : packageResourceList) packageSupport.loadPackageFromClasspath(packageResource);
+        final var chain = new ValidationSupportChain(
+                packageSupport,
+                new DefaultProfileValidationSupport(context),
+                (txServer != null && !txServer.isBlank())? new RemoteTerminologyServiceValidationSupport(context, txServer)
+                        : new InMemoryTerminologyServerValidationSupport(context),
+                new CommonCodeSystemsTerminologyService(context)
+        );
+        validator = context.newValidator();
+        final var instanceValidator = new FhirInstanceValidator(chain);
+        validator.registerValidatorModule(instanceValidator);
+    }
+
+    @Override
+    public ValidationResult validateDocumentBundle(final InputStream documentStream,
+                                                   final ChEmedEprDocument document,
+                                                   final Manager.FhirFormat streamFormat)
+            throws IOException {
+        final var validationOptions = new ValidationOptions();
+        validationOptions.addProfile(document.getEmedType().getProfile());
+        final var result =
+                validator.validateWithResult(new String(documentStream.readAllBytes(), StandardCharsets.UTF_8), validationOptions);
+        final var huskyResult = ChEmedEprValidator.toHuskyValidationResult((OperationOutcome) result.toOperationOutcome());
+        if (huskyResult.isSuccessful())
+            huskyResult.add(logicValidator.validate(document));
+        logValidationResult(huskyResult);
+        return huskyResult;
+    }
+
+    @Override
+    public ValidationResult validateDocumentBundle(final Bundle bundle, final String profile) {
+        final var validationOptions = new ValidationOptions();
+        validationOptions.addProfile(Objects.requireNonNull(profile));
+        final var result = validator.validateWithResult(Objects.requireNonNull(bundle), validationOptions);
+        final var huskyResult =
+                ChEmedEprValidator.toHuskyValidationResult((OperationOutcome) result.toOperationOutcome());
+        logValidationResult(huskyResult);
+        return huskyResult;
+    }
+
+    /**
+     * Logs a validation result as info messages, to loosely imitate matchbox-engine behaviour.
+     * @param validationResult The validation result to be logged.
+     */
+    private void logValidationResult(final ValidationResult validationResult) {
+        log.info("Validation result: {}", validationResult.isSuccessful()? "successful" : "failed");
+        for (final var issue : validationResult.getIssues())
+            log.info(issue.toString());
+    }
+}

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprMatchboxValidator.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprMatchboxValidator.java
@@ -1,0 +1,100 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ *
+ */
+package org.projecthusky.fhir.emed.ch.epr.validator;
+
+import ch.ahdis.matchbox.engine.MatchboxEngine;
+import ch.ahdis.matchbox.engine.MatchboxEngine.FilesystemPackageCacheMode;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r5.elementmodel.Manager;
+import org.hl7.fhir.r5.utils.EOperationOutcome;
+import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprDocument;
+import org.projecthusky.fhir.emed.ch.epr.validator.logicvalidator.LogicValidator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+
+/**
+ * <a href="https://github.com/ahdis/matchbox">matchbox-engine</a> Implementation of {@link ChEmedEprValidator}.
+ */
+public class ChEmedEprMatchboxValidator implements ChEmedEprValidator {
+
+    /**
+     * The instance validator.
+     */
+    private final MatchboxEngine matchboxEngine;
+
+    /**
+     * The logic validator.
+     */
+    private final LogicValidator logicValidator = new LogicValidator();
+
+    /**
+     * Creates an instance of an offline validator with matchbox as validation engine.
+     *
+     * @throws IOException if the NPM packages can't be found in the classpath.
+     */
+    public ChEmedEprMatchboxValidator() throws IOException, URISyntaxException {
+        this(null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param txServer The URL of the terminology server to be used for validation. If null, no external terminology
+     *                 services will be used for the validation.
+     * @throws IOException if the NPM packages can't be found in the classpath.
+     */
+    public ChEmedEprMatchboxValidator(final @Nullable String txServer)  throws IOException, URISyntaxException {
+        final var builder = new MatchboxEngine.MatchboxEngineBuilder();
+        builder.setTxServer(txServer);
+        builder.setPackageCacheMode(FilesystemPackageCacheMode.TESTING);
+        this.matchboxEngine = builder.getEngineR4();
+
+        // Adding all necessary packages
+        for (final var packageResource : packageResourceList)
+            this.matchboxEngine.loadPackage(getClass().getResourceAsStream(packageResource));
+    }
+
+    @Override
+    public ValidationResult validateDocumentBundle(final InputStream documentStream,
+                                                   final ChEmedEprDocument document,
+                                                   final Manager.FhirFormat streamFormat)
+            throws EOperationOutcome, IOException {
+        // First validation pass with the instance validator (matchbox-engine)
+        final OperationOutcome outcome = this.matchboxEngine.validate(
+                documentStream,
+                streamFormat,
+                document.getEmedType().getProfile()
+        );
+        final var result = ChEmedEprValidator.toHuskyValidationResult(outcome);
+        if (!result.isSuccessful()) {
+            return result;
+        }
+
+        // Second validation pass with the logic validator
+        result.getIssues().addAll(this.logicValidator.validate(document));
+        return result;
+    }
+
+    @Override
+    public ValidationResult validateDocumentBundle(final Bundle bundle,
+                                                   final String profile
+    ) throws EOperationOutcome, IOException {
+        // First validation pass with the instance validator (matchbox-engine)
+        final OperationOutcome outcome = this.matchboxEngine.validate(bundle, profile);
+
+        return ChEmedEprValidator.toHuskyValidationResult(outcome);
+    }
+}

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidator.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidator.java
@@ -1,142 +1,69 @@
-/*
- * This code is made available under the terms of the Eclipse Public License v1.0
- * in the github project https://github.com/project-husky/husky there you also
- * find a list of the contributors and the license information.
- *
- * This project has been developed further and modified by the joined working group Husky
- * on the basis of the eHealth Connector opensource project from June 28, 2021,
- * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
- *
- */
 package org.projecthusky.fhir.emed.ch.epr.validator;
 
-import ch.ahdis.matchbox.engine.MatchboxEngine;
-import ch.ahdis.matchbox.engine.MatchboxEngine.FilesystemPackageCacheMode;
-
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
-import org.projecthusky.fhir.emed.ch.common.enums.EmedDocumentType;
 import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprDocument;
-import org.projecthusky.fhir.emed.ch.epr.validator.logicvalidator.LogicValidator;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
  * A CH-EMED-EPR validator. It doesn't use the Schema or Schematron validators but only the Instance one, which is built
  * upon the CH-EMED-EPR IG.
+ * <p>
+ *     This interface should be independent of the actual validation engine being used. Engine-specific implementations
+ *     of this interface should cover their specifics.
+ * </p>
  *
  * @author Quentin Ligier
  **/
-public class ChEmedEprValidator {
+public interface ChEmedEprValidator {
+    List<String> packageResourceList = List.of(
+            "/package/ihe.formatcode.fhir#1.3.0.tgz",
+            "/package/ch.fhir.ig.ch-term#3.1.0.tgz",
+            "/package/ch.fhir.ig.ch-core#5.0.0.tgz",
+            "/package/ch.fhir.ig.ch-emed#5.0.0.tgz",
+            "/package/ch.fhir.ig.ch-emed-epr#2.0.0.tgz",
+            "/package/ch.fhir.ig.ch-epr-fhir#4.0.1.tgz",
+            "/package/ihe.iti.mhd#4.2.2.tgz"
+            );
 
     /**
-     * The instance validator.
-     */
-    private final MatchboxEngine matchboxEngine;
-
-    /**
-     * The logic validator.
-     */
-    private final LogicValidator logicValidator = new LogicValidator();
-
-    /**
-     * Constructor.
-     *
-     * @throws IOException if the NPM packages can't be found in the classpath.
-     */
-    public ChEmedEprValidator() throws IOException, URISyntaxException {
-        this(null);
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param txServer The URL of the terminology server to be used for validation.
-     * @throws IOException if the NPM packages can't be found in the classpath.
-     */
-    public ChEmedEprValidator(final @Nullable String txServer)  throws IOException, URISyntaxException {
-        final var builder = new MatchboxEngine.MatchboxEngineBuilder();
-        builder.setTxServer(txServer);
-        builder.setPackageCacheMode(FilesystemPackageCacheMode.TESTING);
-        this.matchboxEngine = builder.getEngineR4();
-
-        // Adding all necessary packages
-        this.matchboxEngine.loadPackage(getClass().getResourceAsStream("/package/ihe.formatcode.fhir#1.3.0.tgz"));
-        this.matchboxEngine.loadPackage(getClass().getResourceAsStream("/package/ch.fhir.ig.ch-term#3.1.0.tgz"));
-        this.matchboxEngine.loadPackage(getClass().getResourceAsStream("/package/ch.fhir.ig.ch-core#5.0.0.tgz"));
-        this.matchboxEngine.loadPackage(getClass().getResourceAsStream("/package/ch.fhir.ig.ch-emed#5.0.0.tgz"));
-        this.matchboxEngine.loadPackage(getClass().getResourceAsStream("/package/ch.fhir.ig.ch-emed-epr#2.0.0.tgz"));
-        this.matchboxEngine.loadPackage(getClass().getResourceAsStream("/package/ch.fhir.ig.ch-epr-fhir#4.0.1.tgz"));
-        this.matchboxEngine.loadPackage(getClass().getResourceAsStream("/package/ihe.iti.mhd#4.2.2.tgz"));
-    }
-
-    /**
-     * Validates a CH-EMED-EPR document Bundle.
+     * Validates a CH-EMED-EPR document Bundle AND performs a logic validation of the content as well.
      *
      * @param documentStream The document Bundle to validate as a stream.
+     * @param document       The parsed CH EMED EPR document, for the logic validator.
+     * @param streamFormat   The FHIR format of the document stream content.
      * @return the validation result.
      * @implNote We need the parsed document for the logical validator and the serialized document for the instance
      * validator, because HAPI's parser messes with resource IDs.
      */
-    public ValidationResult validateDocumentBundle(final InputStream documentStream,
-                                                   final ChEmedEprDocument document,
-                                                   final Manager.FhirFormat streamFormat)
-            throws EOperationOutcome, IOException {
-        // First validation pass with the instance validator (matchbox-engine)
-        final OperationOutcome outcome = this.matchboxEngine.validate(
-                documentStream,
-                streamFormat,
-                this.getProfileUrl(document.getEmedType())
-        );
-        final var result = new ValidationResult(outcome.getIssue().stream().map(this::mapIssue).collect(Collectors.toList()));
-        if (!result.isSuccessful()) {
-            return result;
-        }
-
-        // Second validation pass with the logic validator
-        result.getIssues().addAll(this.logicValidator.validate(document));
-        return result;
-    }
-
-    public ValidationResult validateDocumentBundle(final Bundle bundle,
-                                                   final String profile
-                                                   ) throws EOperationOutcome, IOException {
-        // First validation pass with the instance validator (matchbox-engine)
-        final OperationOutcome outcome = this.matchboxEngine.validate(bundle, profile);
-
-        final var result = new ValidationResult(outcome.getIssue().stream().map(this::mapIssue).collect(Collectors.toList()));
-        if (!result.isSuccessful()) {
-            return result;
-        }
-
-        return result;
-    }
+    ValidationResult validateDocumentBundle(final InputStream documentStream,
+                                            final ChEmedEprDocument document,
+                                            final Manager.FhirFormat streamFormat) throws EOperationOutcome, IOException;
 
     /**
-     * Returns the profile URL from the eMed type.
+     * Validates a CH-EMED-EPR document Bundle. No logic validation is performed on the content.
      *
-     * @param type The eMed type.
-     * @return the profile URL.
+     * @param bundle  The document Bundle to be validated.
+     * @param profile The profile to match the bundle against.
+     * @return the validation result.
      */
-    protected String getProfileUrl(final EmedDocumentType type) {
-        return switch (type) {
-            case MTP -> "http://fhir.ch/ig/ch-emed-epr/StructureDefinition/ch-emed-epr-document-medicationtreatmentplan";
-            case PRE -> "http://fhir.ch/ig/ch-emed-epr/StructureDefinition/ch-emed-epr-document-medicationprescription";
-            case DIS -> "http://fhir.ch/ig/ch-emed-epr/StructureDefinition/ch-emed-epr-document-medicationdispense";
-            case PADV -> "http://fhir.ch/ig/ch-emed-epr/StructureDefinition/ch-emed-epr-document-pharmaceuticaladvice";
-            case PML -> "http://fhir.ch/ig/ch-emed-epr/StructureDefinition/ch-emed-epr-document-medicationlist";
-            case PMLC -> "http://fhir.ch/ig/ch-emed-epr/StructureDefinition/ch-emed-epr-document-medicationcard";
-        };
-    }
+    ValidationResult validateDocumentBundle(final Bundle bundle,
+                                                   final String profile
+    ) throws EOperationOutcome, IOException;
 
-    protected ValidationIssue mapIssue(final OperationOutcome.OperationOutcomeIssueComponent component) {
+    /**
+     * Maps an {@link OperationOutcome} issue to Husky's own model of a validation issue.
+     * @param component The FHIR operation outcome issue.
+     * @return The translated Husky validation issue.
+     */
+    static ValidationIssue mapIssue(final OperationOutcome.OperationOutcomeIssueComponent component) {
         Integer line = null, column = null;
         String source = null, messageId = null;
         for (final Extension extension : component.getExtension()) {
@@ -149,15 +76,25 @@ public class ChEmedEprValidator {
                         messageId = extension.castToString(extension.getValue()).getValue();
             }
         }
+        String msg = null;
+        if (component.hasDetails() && component.getDetails().hasText()) msg = component.getDetails().getText();
+        else if (component.hasDiagnostics()) msg = component.getDiagnostics();
         return new ValidationIssue(
                 component.getSeverity(),
                 component.getCode(),
-                (component.hasExpression()) ? component.getExpression().get(0).getValueNotNull() : null,
-                (component.hasDetails() && component.getDetails().hasText()) ? component.getDetails().getText() : null,
+                (component.hasExpression()) ? component.getExpression().getFirst().getValueNotNull() : null,
+                msg,
                 line,
                 column,
                 source,
                 messageId
         );
+    }
+
+    /**
+     * Translates a FHIR operation outcome to a Husky validation result.
+     */
+    static ValidationResult toHuskyValidationResult(final OperationOutcome operationOutcome) {
+        return new ValidationResult(operationOutcome.getIssue().stream().map(ChEmedEprValidator::mapIssue).collect(Collectors.toList()));
     }
 }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidator.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/main/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidator.java
@@ -13,12 +13,12 @@ package org.projecthusky.fhir.emed.ch.epr.validator;
 import ch.ahdis.matchbox.engine.MatchboxEngine;
 import ch.ahdis.matchbox.engine.MatchboxEngine.FilesystemPackageCacheMode;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.OperationOutcome;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
-import org.hl7.fhir.utilities.npm.FilesystemPackageCacheManager;
 import org.projecthusky.fhir.emed.ch.common.enums.EmedDocumentType;
 import org.projecthusky.fhir.emed.ch.epr.resource.ChEmedEprDocument;
 import org.projecthusky.fhir.emed.ch.epr.validator.logicvalidator.LogicValidator;
@@ -52,8 +52,18 @@ public class ChEmedEprValidator {
      * @throws IOException if the NPM packages can't be found in the classpath.
      */
     public ChEmedEprValidator() throws IOException, URISyntaxException {
+        this(null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param txServer The URL of the terminology server to be used for validation.
+     * @throws IOException if the NPM packages can't be found in the classpath.
+     */
+    public ChEmedEprValidator(final @Nullable String txServer)  throws IOException, URISyntaxException {
         final var builder = new MatchboxEngine.MatchboxEngineBuilder();
-        builder.setTxServer(null);
+        builder.setTxServer(txServer);
         builder.setPackageCacheMode(FilesystemPackageCacheMode.TESTING);
         this.matchboxEngine = builder.getEngineR4();
 

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/test/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidatorTest.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/test/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidatorTest.java
@@ -3,7 +3,6 @@ package org.projecthusky.fhir.emed.ch.epr.validator;
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.projecthusky.fhir.emed.ch.common.enums.EmedDocumentType;
 import org.projecthusky.fhir.emed.ch.epr.service.ChEmedEprParser;
@@ -25,10 +24,9 @@ class ChEmedEprValidatorTest {
     private static final Logger log = LoggerFactory.getLogger(ChEmedEprValidatorTest.class);
 
     @Test
-    @Disabled("TODO: Due to new version of matchbox? failure!")
     void validateDocumentBundle() throws IOException, URISyntaxException, EOperationOutcome {
         final var ctx = FhirContext.forR4Cached();
-        final var validator = new ChEmedEprValidator();
+        final var validator = new ChEmedEprValidator("http://tx.fhir.org/");
         final var parser = new ChEmedEprParser(ctx);
 
         final var xml = new String(getClass().getResourceAsStream("/Bundle-1-1-MedicationTreatmentPlan.xml").readAllBytes());

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/test/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidatorTest.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/test/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidatorTest.java
@@ -3,6 +3,7 @@ package org.projecthusky.fhir.emed.ch.epr.validator;
 import ca.uhn.fhir.context.FhirContext;
 import org.hl7.fhir.r5.elementmodel.Manager;
 import org.hl7.fhir.r5.utils.EOperationOutcome;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.projecthusky.fhir.emed.ch.common.enums.EmedDocumentType;
 import org.projecthusky.fhir.emed.ch.epr.service.ChEmedEprParser;
@@ -16,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Tests for {@link ChEmedEprValidator}.
+ * Tests for {@link ChEmedEprMatchboxValidator}.
  *
  * @author Quentin Ligier
  **/
@@ -24,9 +25,20 @@ class ChEmedEprValidatorTest {
     private static final Logger log = LoggerFactory.getLogger(ChEmedEprValidatorTest.class);
 
     @Test
-    void validateDocumentBundle() throws IOException, URISyntaxException, EOperationOutcome {
+    void validateDocumentBundleWithMatchbox() throws IOException, URISyntaxException, EOperationOutcome {
         final var ctx = FhirContext.forR4Cached();
-        final var validator = new ChEmedEprValidator("https://tx.fhir.org/");
+        final var validator = new ChEmedEprMatchboxValidator("https://tx.fhir.org/");
+        performValidate(ctx, validator);
+    }
+
+    @Test @Disabled("Current fhir core version in the project, aligned with Matchbox', is newer than HAPI FHIR's, it is incompatible and will make this test fail.")
+    void validateDocumentBundleWithHapi() throws IOException, URISyntaxException, EOperationOutcome {
+        final var ctx = FhirContext.forR4Cached();
+        final var validator = new ChEmedEprHapiValidator(ctx);
+        performValidate(ctx, validator);
+    }
+
+    private void performValidate(final FhirContext ctx, final ChEmedEprValidator validator) throws IOException, EOperationOutcome {
         final var parser = new ChEmedEprParser(ctx);
 
         final var xml = new String(getClass().getResourceAsStream("/Bundle-1-1-MedicationTreatmentPlan.xml").readAllBytes());
@@ -36,14 +48,14 @@ class ChEmedEprValidatorTest {
 
         for (final var message : results.getIssues()) {
             log.info(String.format("[%s][%s] %s", message.getSeverity().name(), message.getType().name(),
-                                   message.getMessage()));
+                    message.getMessage()));
         }
 
         assertTrue(results.isSuccessful());
         final var preDocument = parser.parse(xml, EmedDocumentType.PRE);
         results = validator.validateDocumentBundle(getClass().getResourceAsStream("/Bundle-1-1-MedicationTreatmentPlan.xml"),
-                                                   preDocument,
-                                                   Manager.FhirFormat.XML);
+                preDocument,
+                Manager.FhirFormat.XML);
         assertFalse(results.isSuccessful());
     }
 }

--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/test/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidatorTest.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr/src/test/java/org/projecthusky/fhir/emed/ch/epr/validator/ChEmedEprValidatorTest.java
@@ -26,7 +26,7 @@ class ChEmedEprValidatorTest {
     @Test
     void validateDocumentBundle() throws IOException, URISyntaxException, EOperationOutcome {
         final var ctx = FhirContext.forR4Cached();
-        final var validator = new ChEmedEprValidator("http://tx.fhir.org/");
+        final var validator = new ChEmedEprValidator("https://tx.fhir.org/");
         final var parser = new ChEmedEprParser(ctx);
 
         final var xml = new String(getClass().getResourceAsStream("/Bundle-1-1-MedicationTreatmentPlan.xml").readAllBytes());


### PR DESCRIPTION
closes #248 

This PR is based on the PR #246 branch.

This PR transforms the ChEmedEprValidator into an interface with two implementations: one using matchbox-engine and one simply using HAPI's.

The caveat is that we cannot specify in the dependencies a version of FHIR core that will work with both, because matchbox-engine needs a more up-to-date version of FHIR core than HAPI. I have left the pom with the more up to date version as it was and the HAPI validator test disabled, taking into account as well that any existing implementations are now using a matchbox-engine based solution.