### PR TITLE
[#239] Update OpenHtmlToPdfAConverter to generate as PDF/A-2 instead …

### DIFF
--- a/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/java/org/projecthusky/fhir/emed/ch/epr/narrative/pdf/OpenHtmlToPdfAConverter.java
+++ b/husky-fhir/husky-fhir-emed-ch/husky-fhir-emed-ch-epr-narrative/src/main/java/org/projecthusky/fhir/emed/ch/epr/narrative/pdf/OpenHtmlToPdfAConverter.java
@@ -138,7 +138,7 @@ public class OpenHtmlToPdfAConverter implements HtmlToPdfAConverter {
             builder.withProducer(this.producerName);
         }
         builder.useFastMode();
-        builder.usePdfAConformance(PdfRendererBuilder.PdfAConformance.PDFA_1_A);
+        builder.usePdfAConformance(PdfRendererBuilder.PdfAConformance.PDFA_2_A);
         builder.usePdfUaAccessibility(false);
         if (this.pdfRendererBuilderConsumer != null) {
             this.pdfRendererBuilderConsumer.accept(builder);


### PR DESCRIPTION
closes #279 

it consists of a backport of the very minor #239 fix , affecting only CH EMED EPR pdf generation.