### PR TITLE
Feat/elga immunization update

### DIFF
--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrEntryIndikationsgruppeProblem.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrEntryIndikationsgruppeProblem.java
@@ -1,0 +1,282 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor;
+
+import java.util.List;
+import javax.annotation.processing.Generated;
+import org.projecthusky.common.hl7cdar2.ANY;
+import org.projecthusky.common.hl7cdar2.ObjectFactory;
+import org.projecthusky.common.hl7cdar2.POCDMT000040Observation;
+
+/**
+ * atcdabbr_entry_IndikationsgruppeProblem
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.11.3.21<br>
+ * Effective date: 2023-03-30 08:38:27<br>
+ * Version: 1.1.1+20230717<br>
+ * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--at-cda-bbr-?id=1.2.40.0.34.6.0.11.3.21&amp;effectiveTime=2023-03-30+08%3A38%3A27">atcdabbr_entry_IndikationsgruppeProblem</a> page.
+ */
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
+public class AtcdabbrEntryIndikationsgruppeProblem extends POCDMT000040Observation {
+
+    public AtcdabbrEntryIndikationsgruppeProblem() {
+        super.getClassCode().add("OBS");
+        super.setMoodCode(org.projecthusky.common.hl7cdar2.XActMoodDocumentObservation.EVN);
+        super.setNegationInd(false);
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.3.21"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("2.16.840.1.113883.10.20.1.28"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.4.5"));
+        super.setCode(createHl7CodeFixedValue("55607006",
+                                              "2.16.840.1.113883.6.96",
+                                              null,
+                                              null));
+        super.setCode(createHl7CodeFixedValue("SNOMED CT",
+                                              null,
+                                              null,
+                                              null));
+        super.setStatusCode(createHl7StatusCodeFixedValue("completed",
+                                                          null,
+                                                          null,
+                                                          null));
+        super.getValue().add(createHl7ValueFixedValue());
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Code
+     *
+     * @param code the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.CE createHl7CodeFixedValue(String code, String codeSystem, String codeSystemName, String displayName) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.CE retVal = factory.createCE();
+        retVal.setCode(code);
+        retVal.setCodeSystem(codeSystem);
+        retVal.setCodeSystemName(codeSystemName);
+        retVal.setDisplayName(displayName);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Participant
+     *
+     * @param typeCode the desired fixed value for this argument.
+     * @param contextControlCode the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.POCDMT000040Participant2 createHl7ParticipantFixedValue(String typeCode, String contextControlCode) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.POCDMT000040Participant2 retVal = factory.createPOCDMT000040Participant2();
+        retVal.getTypeCode().add(typeCode);
+        retVal.setContextControlCode(contextControlCode);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7StatusCode
+     *
+     * @param code the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.CS createHl7StatusCodeFixedValue(String code, String codeSystem, String codeSystemName, String displayName) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.CS retVal = factory.createCS();
+        retVal.setCode(code);
+        retVal.setCodeSystem(codeSystem);
+        retVal.setCodeSystemName(codeSystemName);
+        retVal.setDisplayName(displayName);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7TemplateId
+     *
+     * @param root the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.II createHl7TemplateIdFixedValue(String root) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.II retVal = factory.createII();
+        retVal.setRoot(root);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Value
+     */
+    private static org.projecthusky.common.hl7cdar2.CD createHl7ValueFixedValue() {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.CD retVal = factory.createCD();
+        return retVal;
+    }
+
+    /**
+     * Gets the hl7Code
+     */
+    public org.projecthusky.common.hl7cdar2.CE getHl7Code() {
+        return (org.projecthusky.common.hl7cdar2.CE) code;
+    }
+
+    /**
+     * Gets the hl7EffectiveTime
+     */
+    public org.projecthusky.common.hl7cdar2.IVLTS getHl7EffectiveTime() {
+        return effectiveTime;
+    }
+
+    /**
+     * Gets the hl7Id
+     */
+    public List<org.projecthusky.common.hl7cdar2.II> getHl7Id() {
+        return id;
+    }
+
+    /**
+     * Gets the hl7Participant
+     */
+    public List<org.projecthusky.common.hl7cdar2.POCDMT000040Participant2> getHl7Participant() {
+        return participant;
+    }
+
+    /**
+     * Gets the hl7StatusCode
+     */
+    public org.projecthusky.common.hl7cdar2.CS getHl7StatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Gets the hl7TemplateId
+     */
+    public List<org.projecthusky.common.hl7cdar2.II> getHl7TemplateId() {
+        return templateId;
+    }
+
+    /**
+     * Gets the hl7Text
+     */
+    public org.projecthusky.common.hl7cdar2.ED getHl7Text() {
+        return text;
+    }
+
+    /**
+     * Gets the hl7Value
+     */
+    public List<ANY> getHl7Value() {
+        return value;
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.CE, filled by: "55607006", "2.16.840.1.113883.6.96", null, null
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.CE getPredefinedCode556070062168401113883696NullNull() {
+        return createHl7CodeFixedValue("55607006",
+                                       "2.16.840.1.113883.6.96",
+                                       null,
+                                       null);
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.CE, filled by: "SNOMED CT", null, null, null
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.CE getPredefinedCodeSnomedCtNullNullNull() {
+        return createHl7CodeFixedValue("SNOMED CT",
+                                       null,
+                                       null,
+                                       null);
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.POCDMT000040Participant2, filled by: "AUT", "OP"
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.POCDMT000040Participant2 getPredefinedParticipantAutOp() {
+        return createHl7ParticipantFixedValue("AUT",
+                                              "OP");
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.POCDMT000040Participant2, filled by: "ENT", "OP"
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.POCDMT000040Participant2 getPredefinedParticipantEntOp() {
+        return createHl7ParticipantFixedValue("ENT",
+                                              "OP");
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.POCDMT000040Participant2, filled by: "VRF", "OP"
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.POCDMT000040Participant2 getPredefinedParticipantVrfOp() {
+        return createHl7ParticipantFixedValue("VRF",
+                                              "OP");
+    }
+
+    /**
+     * Sets the hl7Code
+     */
+    public void setHl7Code(org.projecthusky.common.hl7cdar2.CE value) {
+        this.code = value;
+    }
+
+    /**
+     * Sets the hl7EffectiveTime
+     */
+    public void setHl7EffectiveTime(org.projecthusky.common.hl7cdar2.IVLTS value) {
+        this.effectiveTime = value;
+    }
+
+    /**
+     * Sets the hl7Id
+     */
+    public void setHl7Id(org.projecthusky.common.hl7cdar2.II value) {
+        getId().clear();
+        getId().add(value);
+    }
+
+    /**
+     * Sets the hl7Participant
+     */
+    public void setHl7Participant(org.projecthusky.common.hl7cdar2.POCDMT000040Participant2 value) {
+        getParticipant().clear();
+        getParticipant().add(value);
+    }
+
+    /**
+     * Sets the hl7StatusCode
+     */
+    public void setHl7StatusCode(org.projecthusky.common.hl7cdar2.CS value) {
+        this.statusCode = value;
+    }
+
+    /**
+     * Sets the hl7TemplateId
+     */
+    public void setHl7TemplateId(org.projecthusky.common.hl7cdar2.II value) {
+        getTemplateId().clear();
+        getTemplateId().add(value);
+    }
+
+    /**
+     * Sets the hl7Text
+     */
+    public void setHl7Text(org.projecthusky.common.hl7cdar2.ED value) {
+        this.text = value;
+    }
+
+    /**
+     * Sets the hl7Value
+     */
+    public void setHl7Value(org.projecthusky.common.hl7cdar2.CD value) {
+        getValue().clear();
+        getValue().add(value);
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrEntryIndikationsgruppeProblemConcern.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrEntryIndikationsgruppeProblemConcern.java
@@ -1,0 +1,237 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import org.projecthusky.common.basetypes.CodeBaseType;
+import org.projecthusky.common.hl7cdar2.ObjectFactory;
+import org.projecthusky.common.hl7cdar2.POCDMT000040Act;
+import org.projecthusky.common.model.Code;
+
+/**
+ * atcdabbr_entry_IndikationsgruppeProblemConcern
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.11.3.20<br>
+ * Effective date: 2023-04-13 11:13:48<br>
+ * Version: 1.0.3+20230717<br>
+ * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--at-cda-bbr-?id=1.2.40.0.34.6.0.11.3.20&amp;effectiveTime=2023-04-13+11%3A13%3A48">atcdabbr_entry_IndikationsgruppeProblemConcern</a> page.
+ */
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
+public class AtcdabbrEntryIndikationsgruppeProblemConcern extends POCDMT000040Act {
+
+    public AtcdabbrEntryIndikationsgruppeProblemConcern() {
+        super.setClassCode(org.projecthusky.common.hl7cdar2.XActClassDocumentEntryAct.ACT);
+        super.setMoodCode(org.projecthusky.common.hl7cdar2.XDocumentActMood.EVN);
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.3.20"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("2.16.840.1.113883.10.20.1.27"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.4.5.1"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.4.5.2"));
+        super.setCode(createHl7CodeFixedValue("NA"));
+        vocabStatusCodeCode.add(new Code(CodeBaseType.builder().withCode("active").build()));
+        vocabStatusCodeCode.add(new Code(CodeBaseType.builder().withCode("completed").build()));
+        super.getEntryRelationship().add(createHl7EntryRelationshipFixedValue("SUBJ",
+                                                                              "false",
+                                                                              "true"));
+    }
+
+    private final List<Code> vocabStatusCodeCode = new ArrayList<>(2);
+
+    /**
+     * Creates fixed contents for CDA Element hl7Code
+     *
+     * @param nullFlavor the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.CE createHl7CodeFixedValue(String nullFlavor) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.CE retVal = factory.createCE();
+        retVal.getNullFlavor().add(nullFlavor);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7EntryRelationship
+     *
+     * @param typeCode the desired fixed value for this argument.
+     * @param inversionInd the desired fixed value for this argument.
+     * @param contextConductionInd the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.POCDMT000040EntryRelationship createHl7EntryRelationshipFixedValue(String typeCode, String inversionInd, String contextConductionInd) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.POCDMT000040EntryRelationship retVal = factory.createPOCDMT000040EntryRelationship();
+        retVal.setTypeCode(org.projecthusky.common.hl7cdar2.XActRelationshipEntryRelationship.fromValue(typeCode));
+        if (inversionInd != null) {
+            retVal.setInversionInd(Boolean.parseBoolean(inversionInd));
+        }
+        if (contextConductionInd != null) {
+            retVal.setContextConductionInd(Boolean.parseBoolean(contextConductionInd));
+        }
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Reference
+     *
+     * @param typeCode the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.POCDMT000040Reference createHl7ReferenceFixedValue(String typeCode) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.POCDMT000040Reference retVal = factory.createPOCDMT000040Reference();
+        retVal.setTypeCode(org.projecthusky.common.hl7cdar2.XActRelationshipExternalReference.fromValue(typeCode));
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7TemplateId
+     *
+     * @param root the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.II createHl7TemplateIdFixedValue(String root) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.II retVal = factory.createII();
+        retVal.setRoot(root);
+        return retVal;
+    }
+
+    /**
+     * Gets the hl7Author
+     */
+    public List<org.projecthusky.common.hl7cdar2.POCDMT000040Author> getHl7Author() {
+        return author;
+    }
+
+    /**
+     * Gets the hl7Code
+     */
+    public org.projecthusky.common.hl7cdar2.CE getHl7Code() {
+        return (org.projecthusky.common.hl7cdar2.CE) code;
+    }
+
+    /**
+     * Gets the hl7EffectiveTime
+     */
+    public org.projecthusky.common.hl7cdar2.IVLTS getHl7EffectiveTime() {
+        return effectiveTime;
+    }
+
+    /**
+     * Gets the hl7EntryRelationship
+     */
+    public List<org.projecthusky.common.hl7cdar2.POCDMT000040EntryRelationship> getHl7EntryRelationship() {
+        return entryRelationship;
+    }
+
+    /**
+     * Gets the hl7Id
+     */
+    public List<org.projecthusky.common.hl7cdar2.II> getHl7Id() {
+        return id;
+    }
+
+    /**
+     * Gets the hl7Reference
+     */
+    public List<org.projecthusky.common.hl7cdar2.POCDMT000040Reference> getHl7Reference() {
+        return reference;
+    }
+
+    /**
+     * Gets the hl7StatusCode
+     */
+    public org.projecthusky.common.hl7cdar2.CS getHl7StatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Gets the hl7TemplateId
+     */
+    public List<org.projecthusky.common.hl7cdar2.II> getHl7TemplateId() {
+        return templateId;
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.POCDMT000040Reference, filled by: "REFR"
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.POCDMT000040Reference getPredefinedReferenceRefr() {
+        return createHl7ReferenceFixedValue("REFR");
+    }
+
+    /**
+     * Returns a list of vocab codes as defined in the ART-DECOR model
+     */
+    public List<Code> getVocabStatusCodeCode() {
+        return vocabStatusCodeCode;
+    }
+
+    /**
+     * Sets the hl7Author
+     */
+    public void setHl7Author(org.projecthusky.common.hl7cdar2.POCDMT000040Author value) {
+        getAuthor().clear();
+        getAuthor().add(value);
+    }
+
+    /**
+     * Sets the hl7Code
+     */
+    public void setHl7Code(org.projecthusky.common.hl7cdar2.CE value) {
+        this.code = value;
+    }
+
+    /**
+     * Sets the hl7EffectiveTime
+     */
+    public void setHl7EffectiveTime(org.projecthusky.common.hl7cdar2.IVLTS value) {
+        this.effectiveTime = value;
+    }
+
+    /**
+     * Sets the hl7EntryRelationship
+     */
+    public void setHl7EntryRelationship(org.projecthusky.common.hl7cdar2.POCDMT000040EntryRelationship value) {
+        getEntryRelationship().clear();
+        getEntryRelationship().add(value);
+    }
+
+    /**
+     * Sets the hl7Id
+     */
+    public void setHl7Id(org.projecthusky.common.hl7cdar2.II value) {
+        getId().clear();
+        getId().add(value);
+    }
+
+    /**
+     * Sets the hl7Reference
+     */
+    public void setHl7Reference(org.projecthusky.common.hl7cdar2.POCDMT000040Reference value) {
+        getReference().clear();
+        getReference().add(value);
+    }
+
+    /**
+     * Sets the hl7StatusCode
+     */
+    public void setHl7StatusCode(org.projecthusky.common.hl7cdar2.CS value) {
+        this.statusCode = value;
+    }
+
+    /**
+     * Sets the hl7TemplateId
+     */
+    public void setHl7TemplateId(org.projecthusky.common.hl7cdar2.II value) {
+        getTemplateId().clear();
+        getTemplateId().add(value);
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrHeaderComponentOfEncompassingEncounterWithId.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrHeaderComponentOfEncompassingEncounterWithId.java
@@ -1,0 +1,62 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor;
+
+import javax.annotation.processing.Generated;
+import org.projecthusky.common.hl7cdar2.ObjectFactory;
+import org.projecthusky.common.hl7cdar2.POCDMT000040Component1;
+
+/**
+ * atcdabbr_header_ComponentOfEncompassingEncounterWithId
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.11.1.50<br>
+ * Effective date: 2023-02-28 10:37:28<br>
+ * Version: 1.0.1+20230717<br>
+ * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--at-cda-bbr-?id=1.2.40.0.34.6.0.11.1.50&amp;effectiveTime=2023-02-28+10%3A37%3A28">atcdabbr_header_ComponentOfEncompassingEncounterWithId</a> page.
+ */
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
+public class AtcdabbrHeaderComponentOfEncompassingEncounterWithId extends POCDMT000040Component1 {
+
+    public AtcdabbrHeaderComponentOfEncompassingEncounterWithId() {
+        super.setTypeCode(org.projecthusky.common.hl7cdar2.ActRelationshipHasComponent.COMP);
+        super.setEncompassingEncounter(createHl7EncompassingEncounterFixedValue("ENC",
+                                                                                "EVN"));
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7EncompassingEncounter
+     *
+     * @param classCode the desired fixed value for this argument.
+     * @param moodCode the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.POCDMT000040EncompassingEncounter createHl7EncompassingEncounterFixedValue(String classCode, String moodCode) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.POCDMT000040EncompassingEncounter retVal = factory.createPOCDMT000040EncompassingEncounter();
+        retVal.getClassCode().add(classCode);
+        retVal.getMoodCode().add(moodCode);
+        return retVal;
+    }
+
+    /**
+     * Gets the hl7EncompassingEncounter
+     */
+    public org.projecthusky.common.hl7cdar2.POCDMT000040EncompassingEncounter getHl7EncompassingEncounter() {
+        return encompassingEncounter;
+    }
+
+    /**
+     * Sets the hl7EncompassingEncounter
+     */
+    public void setHl7EncompassingEncounter(org.projecthusky.common.hl7cdar2.POCDMT000040EncompassingEncounter value) {
+        this.encompassingEncounter = value;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrHeaderDocumentPracticeSettingCode.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrHeaderDocumentPracticeSettingCode.java
@@ -1,0 +1,30 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor;
+
+import javax.annotation.processing.Generated;
+import org.projecthusky.common.hl7cdar2.CD;
+
+/**
+ * atcdabbr_header_DocumentPracticeSettingCode
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.11.1.44<br>
+ * Effective date: 2021-03-01 15:37:20<br>
+ * Version: 1.1.0+20210303<br>
+ * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--at-cda-bbr-?id=1.2.40.0.34.6.0.11.1.44&amp;effectiveTime=2021-03-01+15%3A37%3A20">atcdabbr_header_DocumentPracticeSettingCode</a> page.
+ */
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
+public class AtcdabbrHeaderDocumentPracticeSettingCode extends CD {
+
+    public AtcdabbrHeaderDocumentPracticeSettingCode() {
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrHeaderDocumentTerminologyDate.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabbrHeaderDocumentTerminologyDate.java
@@ -1,0 +1,30 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor;
+
+import javax.annotation.processing.Generated;
+import org.projecthusky.common.hl7cdar2.TS;
+
+/**
+ * atcdabbr_header_DocumentTerminologyDate
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.11.1.46<br>
+ * Effective date: 2021-02-19 11:04:44<br>
+ * Version: 1.0.0+20210219<br>
+ * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--at-cda-bbr-?id=1.2.40.0.34.6.0.11.1.46&amp;effectiveTime=2021-02-19+11%3A04%3A44">atcdabbr_header_DocumentTerminologyDate</a> page.
+ */
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
+public class AtcdabbrHeaderDocumentTerminologyDate extends TS {
+
+    public AtcdabbrHeaderDocumentTerminologyDate() {
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabrrEntryCommentSingleAuthorInformant.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabrrEntryCommentSingleAuthorInformant.java
@@ -1,0 +1,187 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor;
+
+import java.util.List;
+import javax.annotation.processing.Generated;
+import org.projecthusky.common.hl7cdar2.ObjectFactory;
+import org.projecthusky.common.hl7cdar2.POCDMT000040Act;
+
+/**
+ * atcdabrr_entry_Comment_single_author_informant
+ * <p>
+ * Template description: <desc lastTranslated="2023-04-03T13:50:56">This entry allows for a comment to be supplied with each entry.<p>
+ * Identifier: 1.2.40.0.34.6.0.11.3.17<br>
+ * Effective date: 2023-04-03 13:50:56<br>
+ * Version: 1.0.0+20230717<br>
+ * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--at-cda-bbr-?id=1.2.40.0.34.6.0.11.3.17&amp;effectiveTime=2023-04-03+13%3A50%3A56">atcdabrr_entry_Comment_single_author_informant</a> page.
+ */
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
+public class AtcdabrrEntryCommentSingleAuthorInformant extends POCDMT000040Act {
+
+    public AtcdabrrEntryCommentSingleAuthorInformant() {
+        super.setClassCode(org.projecthusky.common.hl7cdar2.XActClassDocumentEntryAct.ACT);
+        super.setMoodCode(org.projecthusky.common.hl7cdar2.XDocumentActMood.EVN);
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.3.17"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("2.16.840.1.113883.10.20.1.40"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.4.2"));
+        super.setCode(createHl7CodeFixedValue("48767-8",
+                                              "2.16.840.1.113883.6.1",
+                                              "LOINC",
+                                              "Annotation comment"));
+        super.setStatusCode(createHl7StatusCodeFixedValue("completed"));
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Code
+     *
+     * @param code the desired fixed value for this argument.
+     * @param codeSystem the desired fixed value for this argument.
+     * @param codeSystemName the desired fixed value for this argument.
+     * @param displayName the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.CD createHl7CodeFixedValue(String code, String codeSystem, String codeSystemName, String displayName) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.CD retVal = factory.createCD();
+        retVal.setCode(code);
+        retVal.setCodeSystem(codeSystem);
+        retVal.setCodeSystemName(codeSystemName);
+        retVal.setDisplayName(displayName);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7StatusCode
+     *
+     * @param code the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.CS createHl7StatusCodeFixedValue(String code) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.CS retVal = factory.createCS();
+        retVal.setCode(code);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7TemplateId
+     *
+     * @param root the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.II createHl7TemplateIdFixedValue(String root) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.II retVal = factory.createII();
+        retVal.setRoot(root);
+        return retVal;
+    }
+
+    /**
+     * Gets the hl7Author
+     */
+    public List<org.projecthusky.common.hl7cdar2.POCDMT000040Author> getHl7Author() {
+        return author;
+    }
+
+    /**
+     * Gets the hl7Code
+     */
+    public org.projecthusky.common.hl7cdar2.CD getHl7Code() {
+        return code;
+    }
+
+    /**
+     * Gets the hl7Id
+     */
+    public List<org.projecthusky.common.hl7cdar2.II> getHl7Id() {
+        return id;
+    }
+
+    /**
+     * Gets the hl7Informant
+     */
+    public List<org.projecthusky.common.hl7cdar2.POCDMT000040Informant12> getHl7Informant() {
+        return informant;
+    }
+
+    /**
+     * Gets the hl7StatusCode
+     */
+    public org.projecthusky.common.hl7cdar2.CS getHl7StatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Gets the hl7TemplateId
+     */
+    public List<org.projecthusky.common.hl7cdar2.II> getHl7TemplateId() {
+        return templateId;
+    }
+
+    /**
+     * Gets the hl7Text
+     */
+    public org.projecthusky.common.hl7cdar2.ED getHl7Text() {
+        return text;
+    }
+
+    /**
+     * Sets the hl7Author
+     */
+    public void setHl7Author(org.projecthusky.common.hl7cdar2.POCDMT000040Author value) {
+        getAuthor().clear();
+        getAuthor().add(value);
+    }
+
+    /**
+     * Sets the hl7Code
+     */
+    public void setHl7Code(org.projecthusky.common.hl7cdar2.CD value) {
+        this.code = value;
+    }
+
+    /**
+     * Sets the hl7Id
+     */
+    public void setHl7Id(org.projecthusky.common.hl7cdar2.II value) {
+        getId().clear();
+        getId().add(value);
+    }
+
+    /**
+     * Sets the hl7Informant
+     */
+    public void setHl7Informant(org.projecthusky.common.hl7cdar2.POCDMT000040Informant12 value) {
+        getInformant().clear();
+        getInformant().add(value);
+    }
+
+    /**
+     * Sets the hl7StatusCode
+     */
+    public void setHl7StatusCode(org.projecthusky.common.hl7cdar2.CS value) {
+        this.statusCode = value;
+    }
+
+    /**
+     * Sets the hl7TemplateId
+     */
+    public void setHl7TemplateId(org.projecthusky.common.hl7cdar2.II value) {
+        getTemplateId().clear();
+        getTemplateId().add(value);
+    }
+
+    /**
+     * Sets the hl7Text
+     */
+    public void setHl7Text(org.projecthusky.common.hl7cdar2.ED value) {
+        this.text = value;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabrrSectionIndikationsgruppenKodiert.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/AtcdabrrSectionIndikationsgruppenKodiert.java
@@ -1,0 +1,210 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor;
+
+import java.util.List;
+import javax.annotation.processing.Generated;
+import org.projecthusky.common.hl7cdar2.ObjectFactory;
+import org.projecthusky.common.hl7cdar2.POCDMT000040Section;
+
+/**
+ * atcdabrr_section_IndikationsgruppenKodiert
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.11.2.4<br>
+ * Effective date: 2026-01-16 12:13:20<br>
+ * Version: 1.0.2+20260204<br>
+ * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--at-cda-bbr-?id=1.2.40.0.34.6.0.11.2.4&amp;effectiveTime=2026-01-16+12%3A13%3A20">atcdabrr_section_IndikationsgruppenKodiert</a> page.
+ */
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
+public class AtcdabrrSectionIndikationsgruppenKodiert extends POCDMT000040Section {
+
+    public AtcdabrrSectionIndikationsgruppenKodiert() {
+        super.getClassCode().add("DOCSECT");
+        super.getMoodCode().add("EVN");
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.2.4"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("2.16.840.1.113883.10.20.1.11"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.3.6"));
+        super.setCode(createHl7CodeFixedValue("11450-4",
+                                              "2.16.840.1.113883.6.1",
+                                              "LOINC"));
+        super.getEntry().add(createHl7EntryFixedValue("DRIV",
+                                                      "true"));
+    }
+
+    /**
+     * Adds a hl7Component
+     */
+    public void addHl7Component(org.projecthusky.common.hl7cdar2.POCDMT000040Component5 value) {
+        getComponent().add(value);
+    }
+
+    /**
+     * Adds a hl7Entry
+     */
+    public void addHl7Entry(org.projecthusky.common.hl7cdar2.POCDMT000040Entry value) {
+        getEntry().add(value);
+    }
+
+    /**
+     * Adds a hl7Component
+     */
+    public void clearHl7Component() {
+        getComponent().clear();
+    }
+
+    /**
+     * Adds a hl7Entry
+     */
+    public void clearHl7Entry() {
+        getEntry().clear();
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Code
+     *
+     * @param code the desired fixed value for this argument.
+     * @param codeSystem the desired fixed value for this argument.
+     * @param codeSystemName the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.CE createHl7CodeFixedValue(String code, String codeSystem, String codeSystemName) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.CE retVal = factory.createCE();
+        retVal.setCode(code);
+        retVal.setCodeSystem(codeSystem);
+        retVal.setCodeSystemName(codeSystemName);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Component
+     *
+     * @param typeCode the desired fixed value for this argument.
+     * @param contextConductionInd the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.POCDMT000040Component5 createHl7ComponentFixedValue(String typeCode, String contextConductionInd) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.POCDMT000040Component5 retVal = factory.createPOCDMT000040Component5();
+        retVal.setTypeCode(org.projecthusky.common.hl7cdar2.ActRelationshipHasComponent.fromValue(typeCode));
+        if (contextConductionInd != null) {
+            retVal.setContextConductionInd(Boolean.parseBoolean(contextConductionInd));
+        }
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7Entry
+     *
+     * @param typeCode the desired fixed value for this argument.
+     * @param contextConductionInd the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.POCDMT000040Entry createHl7EntryFixedValue(String typeCode, String contextConductionInd) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.POCDMT000040Entry retVal = factory.createPOCDMT000040Entry();
+        retVal.setTypeCode(org.projecthusky.common.hl7cdar2.XActRelationshipEntry.fromValue(typeCode));
+        if (contextConductionInd != null) {
+            retVal.setContextConductionInd(Boolean.parseBoolean(contextConductionInd));
+        }
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7TemplateId
+     *
+     * @param root the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.II createHl7TemplateIdFixedValue(String root) {
+        ObjectFactory factory = new ObjectFactory();
+        org.projecthusky.common.hl7cdar2.II retVal = factory.createII();
+        retVal.setRoot(root);
+        return retVal;
+    }
+
+    /**
+     * Gets the hl7Code
+     */
+    public org.projecthusky.common.hl7cdar2.CE getHl7Code() {
+        return code;
+    }
+
+    /**
+     * Gets the hl7Id
+     */
+    public org.projecthusky.common.hl7cdar2.II getHl7Id() {
+        return id;
+    }
+
+    /**
+     * Gets the hl7TemplateId
+     */
+    public List<org.projecthusky.common.hl7cdar2.II> getHl7TemplateId() {
+        return templateId;
+    }
+
+    /**
+     * Gets the hl7Text
+     */
+    public org.projecthusky.common.hl7cdar2.StrucDocText getHl7Text() {
+        return text;
+    }
+
+    /**
+     * Gets the hl7Title
+     */
+    public org.projecthusky.common.hl7cdar2.ST getHl7Title() {
+        return title;
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.POCDMT000040Component5, filled by: "COMP", "true"
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.POCDMT000040Component5 getPredefinedComponentCompTrue() {
+        return createHl7ComponentFixedValue("COMP",
+                                            "true");
+    }
+
+    /**
+     * Sets the hl7Code
+     */
+    public void setHl7Code(org.projecthusky.common.hl7cdar2.CE value) {
+        this.code = value;
+    }
+
+    /**
+     * Sets the hl7Id
+     */
+    public void setHl7Id(org.projecthusky.common.hl7cdar2.II value) {
+        this.id = value;
+    }
+
+    /**
+     * Sets the hl7TemplateId
+     */
+    public void setHl7TemplateId(org.projecthusky.common.hl7cdar2.II value) {
+        getTemplateId().clear();
+        getTemplateId().add(value);
+    }
+
+    /**
+     * Sets the hl7Text
+     */
+    public void setHl7Text(org.projecthusky.common.hl7cdar2.StrucDocText value) {
+        this.text = value;
+    }
+
+    /**
+     * Sets the hl7Title
+     */
+    public void setHl7Title(org.projecthusky.common.hl7cdar2.ST value) {
+        this.title = value;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
@@ -33,8 +33,11 @@ import org.projecthusky.common.hl7cdar2.POCDMT000040ClinicalDocument;
 @Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
 public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040ClinicalDocument {
 
+@javax.xml.bind.annotation.XmlElement(name = "terminologyDate", namespace = "urn:hl7-at:v3")
 private org.projecthusky.common.hl7cdar2.TS hl7atTerminologyDate;
+@javax.xml.bind.annotation.XmlElement(name = "practiceSettingCode", namespace = "urn:hl7-at:v3")
 private org.projecthusky.common.hl7cdar2.CD hl7atPracticeSettingCode;
+@javax.xml.bind.annotation.XmlElement(name = "formatCode", namespace = "urn:hl7-at:v3")
 private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
 
     public EimpfDocumentKompletterImmunisierungsstatus() {

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
@@ -54,6 +54,13 @@ private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
                                               "2.16.840.1.113883.6.1",
                                               null,
                                               "HISTORY OF IMMUNIZATIONS"));
+        CD translation = new CD();
+        translation.setCode("82593-5");
+        translation.setCodeSystem("2.16.840.1.113883.6.1");
+        translation.setCodeSystemName("LOINC");
+        translation.setDisplayName("Immunization summary report");
+        super.getCode().getTranslation().add(translation);
+        super.getCode().getTranslation().add(translation);
         super.setComponent(createHl7ComponentFixedValue("COMP",
                                                         "true"));
     }

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
@@ -11,11 +11,9 @@ package org.projecthusky.cda.elga.generated.artdecor;
 
 import java.util.List;
 import java.util.UUID;
-
 import javax.annotation.processing.Generated;
 import javax.xml.bind.annotation.XmlRootElement;
-
-import org.projecthusky.common.hl7cdar2.CS;
+import org.projecthusky.common.hl7cdar2.CD;
 import org.projecthusky.common.hl7cdar2.II;
 import org.projecthusky.common.hl7cdar2.INT;
 import org.projecthusky.common.hl7cdar2.ObjectFactory;
@@ -23,14 +21,16 @@ import org.projecthusky.common.hl7cdar2.POCDMT000040ClinicalDocument;
 
 /**
  * eimpf_document_KompletterImmunisierungsstatus
- * 
+ * <p>
  * Identifier: 1.2.40.0.34.6.0.11.0.4<br>
- * Effective date: 2022-01-25 12:13:30<br>
- * Version: 1.3.0+20220127<br>
+ * Effective date: 2025-03-17 09:23:13<br>
+ * Version: 2.0.1+20250320<br>
  * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--elgaimpf-?id=1.2.40.0.34.6.0.11.0.4&amp;effectiveTime=2025-03-17+09%3A23%3A13">eimpf_document_KompletterImmunisierungsstatus</a> page.
  */
 @XmlRootElement(name = "ClinicalDocument", namespace = "urn:hl7-org:v3")
-@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2022-02-18")
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
 public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040ClinicalDocument {
 
     public EimpfDocumentKompletterImmunisierungsstatus() {
@@ -38,11 +38,12 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
         super.getMoodCode().add("EVN");
         super.setTypeId(createHl7TypeIdFixedValue("2.16.840.1.113883.1.3",
                                                   "POCD_HD000040"));
-		super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1", null));
-		super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19", null));
-		super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4", null));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019",
-                                                                "1.2.40.0.34.6.0.11.0.4.1"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4",
+                                                                "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4.1",
+                                                                null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.1.18.1.2",
                                                                 null));
         super.setCode(createHl7CodeFixedValue("11369-6",
@@ -51,7 +52,6 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
                                               "HISTORY OF IMMUNIZATIONS"));
         super.setComponent(createHl7ComponentFixedValue("COMP",
                                                         "true"));
-		super.setLanguageCode(createHl7RealmCodeFixedValue("de-AT"));
     }
 
     /**
@@ -68,17 +68,6 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
         retVal.setDisplayName(displayName);
         return retVal;
     }
-
-	/**
-	 * Creates fixed contents for CDA Element hl7realmCode
-	 *
-	 * @param code the desired fixed value for this argument.
-	 */
-	private static org.projecthusky.common.hl7cdar2.CS createHl7RealmCodeFixedValue(String code) {
-		org.projecthusky.common.hl7cdar2.CS retVal = new CS();
-		retVal.setCode(code);
-		return retVal;
-	}
 
     /**
      * Creates fixed contents for CDA Element hl7Component
@@ -121,6 +110,17 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
         org.projecthusky.common.hl7cdar2.POCDMT000040InfrastructureRootTypeId retVal = factory.createPOCDMT000040InfrastructureRootTypeId();
         retVal.setRoot(root);
         retVal.setExtension(extension);
+        return retVal;
+    }
+
+    /**
+     * Creates fixed contents for CDA Element hl7atFormatCode
+     *
+     * @param codeSystemName the desired fixed value for this argument.
+     */
+    private static org.projecthusky.common.hl7cdar2.CD createHl7atFormatCodeFixedValue(String codeSystemName) {
+        org.projecthusky.common.hl7cdar2.CD retVal = new org.projecthusky.common.hl7cdar2.CD();
+        retVal.setCodeSystemName(codeSystemName);
         return retVal;
     }
 
@@ -183,7 +183,7 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
     /**
      * Gets the hl7LanguageCode
      */
-	public CS getHl7LanguageCode() {
+    public org.projecthusky.common.hl7cdar2.CS getHl7LanguageCode() {
         return languageCode;
     }
 
@@ -241,6 +241,45 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
      */
     public org.projecthusky.common.hl7cdar2.INT getHl7VersionNumber() {
         return versionNumber;
+    }
+
+    /**
+     * Gets the hl7atFormatCode
+     */
+    public org.projecthusky.common.hl7cdar2.CD getHl7atFormatCode() {
+        return this;
+    }
+
+    /**
+     * Gets the hl7atPracticeSettingCode
+     */
+    public org.projecthusky.common.hl7cdar2.CD getHl7atPracticeSettingCode() {
+        return this;
+    }
+
+    /**
+     * Gets the hl7atTerminologyDate
+     */
+    public org.projecthusky.common.hl7cdar2.TS getHl7atTerminologyDate() {
+        return this;
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.II, filled by: "1.2.40.0.34.6.0.11.0.4.1", null
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.II getPredefinedTemplateId12400346011041Null() {
+        return createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4.1",
+                                             null);
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.II, filled by: "1.2.40.0.34.6.0.11.0.4", "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.II getPredefinedTemplateId1240034601104XdsdocumentEntryFormatCodeUrnHl7AtEImpf2019() {
+        return createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4",
+                                             "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019");
     }
 
     /**
@@ -339,7 +378,7 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
     /**
      * Sets the hl7LanguageCode
      */
-	public void setHl7LanguageCode(CS value) {
+    public void setHl7LanguageCode(org.projecthusky.common.hl7cdar2.CS value) {
         this.languageCode = value;
     }
 
@@ -401,6 +440,27 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
      */
     public void setHl7VersionNumber(org.projecthusky.common.hl7cdar2.INT value) {
         this.versionNumber = value;
+    }
+
+    /**
+     * Sets the hl7atFormatCode
+     */
+    public void setHl7atFormatCode(org.projecthusky.common.hl7cdar2.CD value) {
+        // TODO: NYI
+    }
+
+    /**
+     * Sets the hl7atPracticeSettingCode
+     */
+    public void setHl7atPracticeSettingCode(org.projecthusky.common.hl7cdar2.CD value) {
+        // TODO: NYI
+    }
+
+    /**
+     * Sets the hl7atTerminologyDate
+     */
+    public void setHl7atTerminologyDate(org.projecthusky.common.hl7cdar2.TS value) {
+        // TODO: NYI
     }
 
     /**

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
@@ -23,23 +23,27 @@ import org.projecthusky.common.hl7cdar2.POCDMT000040ClinicalDocument;
  * eimpf_document_KompletterImmunisierungsstatus
  * <p>
  * Identifier: 1.2.40.0.34.6.0.11.0.4<br>
- * Effective date: 2025-03-17 09:23:13<br>
- * Version: 2.0.1+20250320<br>
+ * Effective date: 2026-02-04 15:09:45<br>
+ * Version: 2.0.2+20260204<br>
  * Status: active
  * <p>
- * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--elgaimpf-?id=1.2.40.0.34.6.0.11.0.4&amp;effectiveTime=2025-03-17+09%3A23%3A13">eimpf_document_KompletterImmunisierungsstatus</a> page.
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--elgaimpf-?id=1.2.40.0.34.6.0.11.0.4&amp;effectiveTime=2026-02-04+15%3A09%3A45">eimpf_document_KompletterImmunisierungsstatus</a> page.
  */
 @XmlRootElement(name = "ClinicalDocument", namespace = "urn:hl7-org:v3")
 @Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
 public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040ClinicalDocument {
+
+private org.projecthusky.common.hl7cdar2.TS hl7atTerminologyDate;
+private org.projecthusky.common.hl7cdar2.CD hl7atPracticeSettingCode;
+private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
 
     public EimpfDocumentKompletterImmunisierungsstatus() {
         super.setClassCode(org.projecthusky.common.hl7cdar2.ActClinicalDocument.DOCCLIN);
         super.getMoodCode().add("EVN");
         super.setTypeId(createHl7TypeIdFixedValue("2.16.840.1.113883.1.3",
                                                   "POCD_HD000040"));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1"));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1", null));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4",
                                                                 "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4.1",
@@ -247,21 +251,21 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
      * Gets the hl7atFormatCode
      */
     public org.projecthusky.common.hl7cdar2.CD getHl7atFormatCode() {
-        return this;
+        return hl7atFormatCode;
     }
 
     /**
      * Gets the hl7atPracticeSettingCode
      */
     public org.projecthusky.common.hl7cdar2.CD getHl7atPracticeSettingCode() {
-        return this;
+        return hl7atPracticeSettingCode;
     }
 
     /**
      * Gets the hl7atTerminologyDate
      */
     public org.projecthusky.common.hl7cdar2.TS getHl7atTerminologyDate() {
-        return this;
+        return hl7atTerminologyDate;
     }
 
     /**
@@ -446,21 +450,21 @@ public class EimpfDocumentKompletterImmunisierungsstatus extends POCDMT000040Cli
      * Sets the hl7atFormatCode
      */
     public void setHl7atFormatCode(org.projecthusky.common.hl7cdar2.CD value) {
-        // TODO: NYI
+        this.hl7atFormatCode = value;
     }
 
     /**
      * Sets the hl7atPracticeSettingCode
      */
     public void setHl7atPracticeSettingCode(org.projecthusky.common.hl7cdar2.CD value) {
-        // TODO: NYI
+        this.hl7atPracticeSettingCode = value;
     }
 
     /**
      * Sets the hl7atTerminologyDate
      */
     public void setHl7atTerminologyDate(org.projecthusky.common.hl7cdar2.TS value) {
-        // TODO: NYI
+        this.hl7atTerminologyDate = value;
     }
 
     /**

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentKompletterImmunisierungsstatus.java
@@ -47,10 +47,7 @@ private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
                                                   "POCD_HD000040"));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2", null));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4",
-                                                                "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4.1",
-                                                                null));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.4", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.1.18.1.2",
                                                                 null));
         super.setCode(createHl7CodeFixedValue("11369-6",

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
@@ -33,8 +33,11 @@ import org.projecthusky.common.hl7cdar2.POCDMT000040ClinicalDocument;
 @Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
 public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040ClinicalDocument {
 
+@javax.xml.bind.annotation.XmlElement(name = "terminologyDate", namespace = "urn:hl7-at:v3")
 private org.projecthusky.common.hl7cdar2.TS hl7atTerminologyDate;
+@javax.xml.bind.annotation.XmlElement(name = "practiceSettingCode", namespace = "urn:hl7-at:v3")
 private org.projecthusky.common.hl7cdar2.CD hl7atPracticeSettingCode;
+@javax.xml.bind.annotation.XmlElement(name = "formatCode", namespace = "urn:hl7-at:v3")
 private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
 
     public EimpfDocumentUpdateImmunisierungsstatus() {

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
@@ -44,8 +44,7 @@ private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
                                                   "POCD_HD000040"));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2", null));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2",
-                                                                "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2.1",
                                                                 null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.1.18.1.2",

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
@@ -48,8 +48,6 @@ private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2", null));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2.1",
-                                                                null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.1.18.1.2",
                                                                 null));
         super.setCode(createHl7CodeFixedValue("11369-6",

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
@@ -23,23 +23,27 @@ import org.projecthusky.common.hl7cdar2.POCDMT000040ClinicalDocument;
  * eimpf_document_UpdateImmunisierungsstatus
  * <p>
  * Identifier: 1.2.40.0.34.6.0.11.0.2<br>
- * Effective date: 2023-01-23 14:48:21<br>
- * Version: 2.0.0+20230717<br>
+ * Effective date: 2026-02-04 15:13:13<br>
+ * Version: 2.0.2+20260204<br>
  * Status: active
  * <p>
- * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--elgaimpf-?id=1.2.40.0.34.6.0.11.0.2&amp;effectiveTime=2023-01-23+14%3A48%3A21">eimpf_document_UpdateImmunisierungsstatus</a> page.
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--elgaimpf-?id=1.2.40.0.34.6.0.11.0.2&amp;effectiveTime=2026-02-04+15%3A13%3A13">eimpf_document_UpdateImmunisierungsstatus</a> page.
  */
 @XmlRootElement(name = "ClinicalDocument", namespace = "urn:hl7-org:v3")
 @Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
 public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040ClinicalDocument {
+
+private org.projecthusky.common.hl7cdar2.TS hl7atTerminologyDate;
+private org.projecthusky.common.hl7cdar2.CD hl7atPracticeSettingCode;
+private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
 
     public EimpfDocumentUpdateImmunisierungsstatus() {
         super.setClassCode(org.projecthusky.common.hl7cdar2.ActClinicalDocument.DOCCLIN);
         super.getMoodCode().add("EVN");
         super.setTypeId(createHl7TypeIdFixedValue("2.16.840.1.113883.1.3",
                                                   "POCD_HD000040"));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1"));
-        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1", null));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2", null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2",
                                                                 "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2.1",
@@ -268,21 +272,21 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
      * Gets the hl7atFormatCode
      */
     public org.projecthusky.common.hl7cdar2.CD getHl7atFormatCode() {
-        return this;
+        return hl7atFormatCode;
     }
 
     /**
      * Gets the hl7atPracticeSettingCode
      */
     public org.projecthusky.common.hl7cdar2.CD getHl7atPracticeSettingCode() {
-        return this;
+        return hl7atPracticeSettingCode;
     }
 
     /**
      * Gets the hl7atTerminologyDate
      */
     public org.projecthusky.common.hl7cdar2.TS getHl7atTerminologyDate() {
-        return this;
+        return hl7atTerminologyDate;
     }
 
     /**
@@ -488,21 +492,21 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
      * Sets the hl7atFormatCode
      */
     public void setHl7atFormatCode(org.projecthusky.common.hl7cdar2.CD value) {
-        // TODO: NYI
+        this.hl7atFormatCode = value;
     }
 
     /**
      * Sets the hl7atPracticeSettingCode
      */
     public void setHl7atPracticeSettingCode(org.projecthusky.common.hl7cdar2.CD value) {
-        // TODO: NYI
+        this.hl7atPracticeSettingCode = value;
     }
 
     /**
      * Sets the hl7atTerminologyDate
      */
     public void setHl7atTerminologyDate(org.projecthusky.common.hl7cdar2.TS value) {
-        // TODO: NYI
+        this.hl7atTerminologyDate = value;
     }
 
     /**

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
@@ -53,6 +53,12 @@ private org.projecthusky.common.hl7cdar2.CD hl7atFormatCode;
                                               "2.16.840.1.113883.6.1",
                                               null,
                                               "HISTORY OF IMMUNIZATIONS"));
+        CD translation = new CD();
+        translation.setCode("87273-9");
+        translation.setCodeSystem("2.16.840.1.113883.6.1");
+        translation.setCodeSystemName("LOINC");
+        translation.setDisplayName("Immunization note");
+        super.getCode().getTranslation().add(translation);
         super.setComponent(createHl7ComponentFixedValue("COMP",
                                                         "true"));
     }

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/EimpfDocumentUpdateImmunisierungsstatus.java
@@ -11,12 +11,9 @@ package org.projecthusky.cda.elga.generated.artdecor;
 
 import java.util.List;
 import java.util.UUID;
-
 import javax.annotation.processing.Generated;
 import javax.xml.bind.annotation.XmlRootElement;
-
 import org.projecthusky.common.hl7cdar2.CD;
-import org.projecthusky.common.hl7cdar2.CS;
 import org.projecthusky.common.hl7cdar2.II;
 import org.projecthusky.common.hl7cdar2.INT;
 import org.projecthusky.common.hl7cdar2.ObjectFactory;
@@ -24,14 +21,16 @@ import org.projecthusky.common.hl7cdar2.POCDMT000040ClinicalDocument;
 
 /**
  * eimpf_document_UpdateImmunisierungsstatus
- * 
+ * <p>
  * Identifier: 1.2.40.0.34.6.0.11.0.2<br>
- * Effective date: 2022-01-25 12:15:38<br>
- * Version: 1.3.0+20220127<br>
+ * Effective date: 2023-01-23 14:48:21<br>
+ * Version: 2.0.0+20230717<br>
  * Status: active
+ * <p>
+ * Generated from the ArtDecor <a href="https://art-decor.org/art-decor/decor-templates--elgaimpf-?id=1.2.40.0.34.6.0.11.0.2&amp;effectiveTime=2023-01-23+14%3A48%3A21">eimpf_document_UpdateImmunisierungsstatus</a> page.
  */
 @XmlRootElement(name = "ClinicalDocument", namespace = "urn:hl7-org:v3")
-@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2022-02-18")
+@Generated(value = "org.projecthusky.codegenerator.cda.ArtDecor2JavaGenerator", date = "2026-02-19")
 public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040ClinicalDocument {
 
     public EimpfDocumentUpdateImmunisierungsstatus() {
@@ -39,11 +38,12 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
         super.getMoodCode().add("EVN");
         super.setTypeId(createHl7TypeIdFixedValue("2.16.840.1.113883.1.3",
                                                   "POCD_HD000040"));
-		super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1", null));
-		super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19", null));
-		super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2", null));
-		super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2.1",
-				"XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.1"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.7.19.2"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2",
+                                                                "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"));
+        super.getTemplateId().add(createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2.1",
+                                                                null));
         super.getTemplateId().add(createHl7TemplateIdFixedValue("1.3.6.1.4.1.19376.1.5.3.1.1.18.1.2",
                                                                 null));
         super.setCode(createHl7CodeFixedValue("11369-6",
@@ -66,27 +66,8 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
         retVal.setCodeSystem(codeSystem);
         retVal.setCodeSystemName(codeSystemName);
         retVal.setDisplayName(displayName);
-
-		retVal.getTranslation()
-				.add(createHl7TranslationFixedValue("87273-9", "2.16.840.1.113883.6.1", null, "Immunization note"));
-
         return retVal;
     }
-
-	/**
-	 * Creates fixed contents for CDA Element hl7Translation
-	 *
-	 * @param code the desired fixed value for this argument.
-	 */
-	private static org.projecthusky.common.hl7cdar2.CD createHl7TranslationFixedValue(String code, String codeSystem,
-                                                                                      String codeSystemName, String displayName) {
-		org.projecthusky.common.hl7cdar2.CD retVal = new CD();
-		retVal.setCode(code);
-		retVal.setCodeSystem(codeSystem);
-		retVal.setCodeSystemName(codeSystemName);
-		retVal.setDisplayName(displayName);
-		return retVal;
-	}
 
     /**
      * Creates fixed contents for CDA Element hl7Component
@@ -133,10 +114,14 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
     }
 
     /**
-     * Gets the hl7Authenticator
+     * Creates fixed contents for CDA Element hl7atFormatCode
+     *
+     * @param codeSystemName the desired fixed value for this argument.
      */
-    public List<org.projecthusky.common.hl7cdar2.POCDMT000040Authenticator> getHl7Authenticator() {
-        return authenticator;
+    private static org.projecthusky.common.hl7cdar2.CD createHl7atFormatCodeFixedValue(String codeSystemName) {
+        org.projecthusky.common.hl7cdar2.CD retVal = new org.projecthusky.common.hl7cdar2.CD();
+        retVal.setCodeSystemName(codeSystemName);
+        return retVal;
     }
 
     /**
@@ -212,7 +197,7 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
     /**
      * Gets the hl7LanguageCode
      */
-	public CS getHl7LanguageCode() {
+    public org.projecthusky.common.hl7cdar2.CS getHl7LanguageCode() {
         return languageCode;
     }
 
@@ -280,6 +265,45 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
     }
 
     /**
+     * Gets the hl7atFormatCode
+     */
+    public org.projecthusky.common.hl7cdar2.CD getHl7atFormatCode() {
+        return this;
+    }
+
+    /**
+     * Gets the hl7atPracticeSettingCode
+     */
+    public org.projecthusky.common.hl7cdar2.CD getHl7atPracticeSettingCode() {
+        return this;
+    }
+
+    /**
+     * Gets the hl7atTerminologyDate
+     */
+    public org.projecthusky.common.hl7cdar2.TS getHl7atTerminologyDate() {
+        return this;
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.II, filled by: "1.2.40.0.34.6.0.11.0.2.1", null
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.II getPredefinedTemplateId12400346011021Null() {
+        return createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2.1",
+                                             null);
+    }
+
+    /**
+     * Adds a predefined org.projecthusky.common.hl7cdar2.II, filled by: "1.2.40.0.34.6.0.11.0.2", "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019"
+     * @return the predefined element.
+     */
+    public static org.projecthusky.common.hl7cdar2.II getPredefinedTemplateId1240034601102XdsdocumentEntryFormatCodeUrnHl7AtEImpf2019() {
+        return createHl7TemplateIdFixedValue("1.2.40.0.34.6.0.11.0.2",
+                                             "XDSdocumentEntry.formatCode^urn:hl7-at:eImpf:2019");
+    }
+
+    /**
      * Sets the version number to 1 and makes sure the setId is the same as the document id.
      * @param newDocId the new doc id
      */
@@ -312,14 +336,6 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
         this.setId(id);
         this.setVersion(setId.getRoot(),
                         version + 1);
-    }
-
-    /**
-     * Sets the hl7Authenticator
-     */
-    public void setHl7Authenticator(org.projecthusky.common.hl7cdar2.POCDMT000040Authenticator value) {
-        getAuthenticator().clear();
-        getAuthenticator().add(value);
     }
 
     /**
@@ -397,7 +413,7 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
     /**
      * Sets the hl7LanguageCode
      */
-	public void setHl7LanguageCode(CS value) {
+    public void setHl7LanguageCode(org.projecthusky.common.hl7cdar2.CS value) {
         this.languageCode = value;
     }
 
@@ -466,6 +482,27 @@ public class EimpfDocumentUpdateImmunisierungsstatus extends POCDMT000040Clinica
      */
     public void setHl7VersionNumber(org.projecthusky.common.hl7cdar2.INT value) {
         this.versionNumber = value;
+    }
+
+    /**
+     * Sets the hl7atFormatCode
+     */
+    public void setHl7atFormatCode(org.projecthusky.common.hl7cdar2.CD value) {
+        // TODO: NYI
+    }
+
+    /**
+     * Sets the hl7atPracticeSettingCode
+     */
+    public void setHl7atPracticeSettingCode(org.projecthusky.common.hl7cdar2.CD value) {
+        // TODO: NYI
+    }
+
+    /**
+     * Sets the hl7atTerminologyDate
+     */
+    public void setHl7atTerminologyDate(org.projecthusky.common.hl7cdar2.TS value) {
+        // TODO: NYI
     }
 
     /**

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EImpfMengenart.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EImpfMengenart.java
@@ -1,0 +1,333 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eImpf_Mengenart values
+ * <p>
+ * EN: ELGA ValueSet for units of measure in e-Impfpass.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.74<br>
+ * Effective date: 2021-11-29 10:44<br>
+ * Version: 2.0.0+20240903<br>
+ * Status: FINAL
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EImpfMengenart implements ValueSetEnumInterface {
+
+    /**
+     * EN: Gram.<br>
+     */
+    GRAM("g",
+         "2.16.840.1.113883.6.8",
+         "Gram",
+         "Gram",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: Hub/Hübe.<br>
+     */
+    HUB_H_BE("{Hub}",
+             "2.16.840.1.113883.6.8",
+             "Hub/Hübe",
+             "Hub/Hübe",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Microgram.<br>
+     */
+    MICROGRAM("ug",
+              "2.16.840.1.113883.6.8",
+              "Microgram",
+              "Microgram",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: MilliGram.<br>
+     */
+    MILLIGRAM("mg",
+              "2.16.840.1.113883.6.8",
+              "MilliGram",
+              "MilliGram",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: MilliLiter.<br>
+     */
+    MILLILITER("mL",
+               "2.16.840.1.113883.6.8",
+               "MilliLiter",
+               "MilliLiter",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: MilliLiterKonzentrat.<br>
+     */
+    MILLILITERKONZENTRAT("mL{Konzentrat}",
+                         "2.16.840.1.113883.6.8",
+                         "MilliLiterKonzentrat",
+                         "MilliLiterKonzentrat",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Stück.<br>
+     */
+    ST_CK("{Stueck}",
+          "2.16.840.1.113883.6.8",
+          "Stück",
+          "Stück",
+          "TOTRANSLATE",
+          "TOTRANSLATE",
+          "TOTRANSLATE");
+
+    /**
+     * EN: Code for Gram.<br>
+     */
+    public static final String GRAM_CODE = "g";
+
+    /**
+     * EN: Code for Hub/Hübe.<br>
+     */
+    public static final String HUB_H_BE_CODE = "{Hub}";
+
+    /**
+     * EN: Code for Microgram.<br>
+     */
+    public static final String MICROGRAM_CODE = "ug";
+
+    /**
+     * EN: Code for MilliGram.<br>
+     */
+    public static final String MILLIGRAM_CODE = "mg";
+
+    /**
+     * EN: Code for MilliLiter.<br>
+     */
+    public static final String MILLILITER_CODE = "mL";
+
+    /**
+     * EN: Code for MilliLiterKonzentrat.<br>
+     */
+    public static final String MILLILITERKONZENTRAT_CODE = "mL{Konzentrat}";
+
+    /**
+     * EN: Code for Stück.<br>
+     */
+    public static final String ST_CK_CODE = "{Stueck}";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.74";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eImpf_Mengenart";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "2.16.840.1.113883.6.8";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EImpfMengenart getEnum(@Nullable final String code) {
+        for (final EImpfMengenart x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EImpfMengenart.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EImpfMengenart x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EImpfMengenart(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfAntikoerperbestimmung.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfAntikoerperbestimmung.java
@@ -1,0 +1,1083 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of  eimpf-antikoerperbestimmung values
+ * <p>
+ * EN: Determination of immunity by laboratory medicine ("Impftiter"), structured according to vaccinations.The code of the groups serves the assignment to the vaccinations.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.13<br>
+ * Effective date: 2023-07-31 00:00<br>
+ * Version: 1.7.0+20250213<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfAntikoerperbestimmung implements ValueSetEnumInterface {
+
+    /**
+     * EN: aP AK qn.<br>
+     */
+    AP_AK_QN_L1("11585-7",
+                "2.16.840.1.113883.6.1",
+                "aP AK qn.",
+                "aP AK qn.",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Cholera AK qn.<br>
+     */
+    CHOLERA_AK_QN_L1("31698-4",
+                     "2.16.840.1.113883.6.1",
+                     "Cholera AK qn.",
+                     "Cholera AK qn.",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Cholera Impfstoff.<br>
+     */
+    CHOLERA_IMPFSTOFF("836383009",
+                      "2.16.840.1.113883.6.96",
+                      "Cholera Impfstoff",
+                      "Cholera Impfstoff",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Covid-19 Impfstoff.<br>
+     */
+    COVID_19_IMPFSTOFF("840534001",
+                       "2.16.840.1.113883.6.96",
+                       "Covid-19 Impfstoff",
+                       "Covid-19 Impfstoff",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie Impfstoff.<br>
+     */
+    DIPHTHERIE_IMPFSTOFF("836381006",
+                         "2.16.840.1.113883.6.96",
+                         "Diphtherie Impfstoff",
+                         "Diphtherie Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Di AK qn.<br>
+     */
+    DI_AK_QN_L1("5115-1",
+                "2.16.840.1.113883.6.1",
+                "Di AK qn.",
+                "Di AK qn.",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Frühsommer-Meningoenzephalitis Impfstoff.<br>
+     */
+    FR_HSOMMER_MENINGOENZEPHALITIS_IMPFSTOFF("836403007",
+                                             "2.16.840.1.113883.6.96",
+                                             "Frühsommer-Meningoenzephalitis Impfstoff",
+                                             "Frühsommer-Meningoenzephalitis Impfstoff",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE"),
+    /**
+     * EN: FSME AK qn.<br>
+     */
+    FSME_AK_QN_L1("31383-3",
+                  "2.16.840.1.113883.6.1",
+                  "FSME AK qn.",
+                  "FSME AK qn.",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Gelbfieber Impfstoff.<br>
+     */
+    GELBFIEBER_IMPFSTOFF("836385002",
+                         "2.16.840.1.113883.6.96",
+                         "Gelbfieber Impfstoff",
+                         "Gelbfieber Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Haemophilus influenzae Typ B Impfstoff.<br>
+     */
+    HAEMOPHILUS_INFLUENZAE_TYP_B_IMPFSTOFF("836380007",
+                                           "2.16.840.1.113883.6.96",
+                                           "Haemophilus influenzae Typ B Impfstoff",
+                                           "Haemophilus influenzae Typ B Impfstoff",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: HAV AK qn.<br>
+     */
+    HAV_AK_QN_L1("22312-3",
+                 "2.16.840.1.113883.6.1",
+                 "HAV AK qn.",
+                 "HAV AK qn.",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: HBV s-AK qn.<br>
+     */
+    HBV_S_AK_QN_L1("16935-9",
+                   "2.16.840.1.113883.6.1",
+                   "HBV s-AK qn.",
+                   "HBV s-AK qn.",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A Impfstoff.<br>
+     */
+    HEPATITIS_A_IMPFSTOFF("836375003",
+                          "2.16.840.1.113883.6.96",
+                          "Hepatitis A Impfstoff",
+                          "Hepatitis A Impfstoff",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Impfstoff.<br>
+     */
+    HEPATITIS_B_IMPFSTOFF("836374004",
+                          "2.16.840.1.113883.6.96",
+                          "Hepatitis B Impfstoff",
+                          "Hepatitis B Impfstoff",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster Impfstoff.<br>
+     */
+    HERPES_ZOSTER_IMPFSTOFF("871919004",
+                            "2.16.840.1.113883.6.96",
+                            "Herpes Zoster Impfstoff",
+                            "Herpes Zoster Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: HiB AK qn.<br>
+     */
+    HIB_AK_QN_L1("7931-9",
+                 "2.16.840.1.113883.6.1",
+                 "HiB AK qn.",
+                 "HiB AK qn.",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Humane Papillomaviren Impfstoff.<br>
+     */
+    HUMANE_PAPILLOMAVIREN_IMPFSTOFF("836379009",
+                                    "2.16.840.1.113883.6.96",
+                                    "Humane Papillomaviren Impfstoff",
+                                    "Humane Papillomaviren Impfstoff",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE"),
+    /**
+     * EN: Influenza A AK qn.<br>
+     */
+    INFLUENZA_A_AK_QN_L1("7920-2",
+                         "2.16.840.1.113883.6.1",
+                         "Influenza A AK qn.",
+                         "Influenza A AK qn.",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Influenza (H1N1) Impfstoff.<br>
+     */
+    INFLUENZA_H1N1_IMPFSTOFF("871772009",
+                             "2.16.840.1.113883.6.96",
+                             "Influenza (H1N1) Impfstoff",
+                             "Influenza (H1N1) Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Influenza (H5N1) Impfstoff.<br>
+     */
+    INFLUENZA_H5N1_IMPFSTOFF("427036009",
+                             "2.16.840.1.113883.6.96",
+                             "Influenza (H5N1) Impfstoff",
+                             "Influenza (H5N1) Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Influenza H5 AK Ti.<br>
+     */
+    INFLUENZA_H5_AK_TI_L1("47454-4",
+                          "2.16.840.1.113883.6.1",
+                          "Influenza H5 AK Ti.",
+                          "Influenza H5 AK Ti.",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Influenza Impfstoff.<br>
+     */
+    INFLUENZA_IMPFSTOFF("836377006",
+                        "2.16.840.1.113883.6.96",
+                        "Influenza Impfstoff",
+                        "Influenza Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Japanische Enzephalitis Impfstoff.<br>
+     */
+    JAPANISCHE_ENZEPHALITIS_IMPFSTOFF("836378001",
+                                      "2.16.840.1.113883.6.96",
+                                      "Japanische Enzephalitis Impfstoff",
+                                      "Japanische Enzephalitis Impfstoff",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: Masern AK qn.<br>
+     */
+    MASERN_AK_QN_L1("7961-6",
+                    "2.16.840.1.113883.6.1",
+                    "Masern AK qn.",
+                    "Masern AK qn.",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Masern Impfstoff.<br>
+     */
+    MASERN_IMPFSTOFF("836382004",
+                     "2.16.840.1.113883.6.96",
+                     "Masern Impfstoff",
+                     "Masern Impfstoff",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Impfstoff.<br>
+     */
+    MENINGOKOKKEN_IMPFSTOFF("836401009",
+                            "2.16.840.1.113883.6.96",
+                            "Meningokokken Impfstoff",
+                            "Meningokokken Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp B Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_B_IMPFSTOFF("1981000221108",
+                                      "2.16.840.1.113883.6.96",
+                                      "Meningokokken Serotyp B Impfstoff",
+                                      "Meningokokken Serotyp B Impfstoff",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp C Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_C_IMPFSTOFF("871866001",
+                                      "2.16.840.1.113883.6.96",
+                                      "Meningokokken Serotyp C Impfstoff",
+                                      "Meningokokken Serotyp C Impfstoff",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: Mpox/Pocken Impfstoff.<br>
+     */
+    MPOX_POCKEN_IMPFSTOFF("836389008",
+                          "2.16.840.1.113883.6.96",
+                          "Mpox/Pocken Impfstoff",
+                          "Mpox/Pocken Impfstoff",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Mumps AK qn.<br>
+     */
+    MUMPS_AK_QN_L1("7965-7",
+                   "2.16.840.1.113883.6.1",
+                   "Mumps AK qn.",
+                   "Mumps AK qn.",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Mumps Impfstoff.<br>
+     */
+    MUMPS_IMPFSTOFF("871738001",
+                    "2.16.840.1.113883.6.96",
+                    "Mumps Impfstoff",
+                    "Mumps Impfstoff",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Pertussis Impfstoff.<br>
+     */
+    PERTUSSIS_IMPFSTOFF("601000221108",
+                        "2.16.840.1.113883.6.96",
+                        "Pertussis Impfstoff",
+                        "Pertussis Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Impfstoff.<br>
+     */
+    PNEUMOKOKKEN_IMPFSTOFF("836398006",
+                           "2.16.840.1.113883.6.96",
+                           "Pneumokokken Impfstoff",
+                           "Pneumokokken Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Poliomyelitis Impfstoff.<br>
+     */
+    POLIOMYELITIS_IMPFSTOFF("1031000221108",
+                            "2.16.840.1.113883.6.96",
+                            "Poliomyelitis Impfstoff",
+                            "Poliomyelitis Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Polio AK qn.<br>
+     */
+    POLIO_AK_QN_L1("16284-2",
+                   "2.16.840.1.113883.6.1",
+                   "Polio AK qn.",
+                   "Polio AK qn.",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Polio virus 1 Ab.<br>
+     */
+    POLIO_VIRUS_1_AB_L1("5281-1",
+                        "2.16.840.1.113883.6.1",
+                        "Polio virus 1 Ab",
+                        "Polio virus 1 Ab",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Polio virus 2 Ab.<br>
+     */
+    POLIO_VIRUS_2_AB_L1("5283-7",
+                        "2.16.840.1.113883.6.1",
+                        "Polio virus 2 Ab",
+                        "Polio virus 2 Ab",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Polio virus 3 Ab.<br>
+     */
+    POLIO_VIRUS_3_AB_L1("5285-2",
+                        "2.16.840.1.113883.6.1",
+                        "Polio virus 3 Ab",
+                        "Polio virus 3 Ab",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Rabies virus Ab.<br>
+     */
+    RABIES_VIRUS_AB_L1("6524-3",
+                       "2.16.840.1.113883.6.1",
+                       "Rabies virus Ab",
+                       "Rabies virus Ab",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Impfstoff.<br>
+     */
+    ROTAVIRUS_IMPFSTOFF("836387005",
+                        "2.16.840.1.113883.6.96",
+                        "Rotavirus Impfstoff",
+                        "Rotavirus Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Rota AK qn.<br>
+     */
+    ROTA_AK_QN_L1("5328-0",
+                  "2.16.840.1.113883.6.1",
+                  "Rota AK qn.",
+                  "Rota AK qn.",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Röteln Ab Tutr Ser HAI.<br>
+     */
+    R_TELN_AB_TUTR_SER_HAI_L1("50694-9",
+                              "2.16.840.1.113883.6.1",
+                              "Röteln Ab Tutr Ser HAI",
+                              "Röteln Ab Tutr Ser HAI",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Röteln AK qn.<br>
+     */
+    R_TELN_AK_QN_L1("8013-5",
+                    "2.16.840.1.113883.6.1",
+                    "Röteln AK qn.",
+                    "Röteln AK qn.",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Röteln IgG AK Ti.<br>
+     */
+    R_TELN_IGG_AK_TI_L1("41763-4",
+                        "2.16.840.1.113883.6.1",
+                        "Röteln IgG AK Ti.",
+                        "Röteln IgG AK Ti.",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Röteln Impfstoff.<br>
+     */
+    R_TELN_IMPFSTOFF("836388000",
+                     "2.16.840.1.113883.6.96",
+                     "Röteln Impfstoff",
+                     "Röteln Impfstoff",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2-AK IgG.<br>
+     */
+    SARS_COV_2_AK_IGG_L1("94505-5",
+                         "2.16.840.1.113883.6.1",
+                         "SARS-CoV-2-AK IgG",
+                         "SARS-CoV-2-AK IgG",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2-AK IgG ql.<br>
+     */
+    SARS_COV_2_AK_IGG_QL_L1("94563-4",
+                            "2.16.840.1.113883.6.1",
+                            "SARS-CoV-2-AK IgG ql.",
+                            "SARS-CoV-2-AK IgG ql.",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2-AK IgG ST.<br>
+     */
+    SARS_COV_2_AK_IGG_ST_L1("94507-1",
+                            "2.16.840.1.113883.6.1",
+                            "SARS-CoV-2-AK IgG ST",
+                            "SARS-CoV-2-AK IgG ST",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2-AK ql.<br>
+     */
+    SARS_COV_2_AK_QL_L1("94547-7",
+                        "2.16.840.1.113883.6.1",
+                        "SARS-CoV-2-AK ql.",
+                        "SARS-CoV-2-AK ql.",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Tetanustoxin AK qn.<br>
+     */
+    TETANUSTOXIN_AK_QN_L1("32775-9",
+                          "2.16.840.1.113883.6.1",
+                          "Tetanustoxin AK qn.",
+                          "Tetanustoxin AK qn.",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Tetanus Impfstoff.<br>
+     */
+    TETANUS_IMPFSTOFF("1101000221104",
+                      "2.16.840.1.113883.6.96",
+                      "Tetanus Impfstoff",
+                      "Tetanus Impfstoff",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Tollwut AK qn.<br>
+     */
+    TOLLWUT_AK_QN_L1("5288-6",
+                     "2.16.840.1.113883.6.1",
+                     "Tollwut AK qn.",
+                     "Tollwut AK qn.",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Impfstoff.<br>
+     */
+    TOLLWUT_IMPFSTOFF("836393002",
+                      "2.16.840.1.113883.6.96",
+                      "Tollwut Impfstoff",
+                      "Tollwut Impfstoff",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Tuberkulose Impfstoff.<br>
+     */
+    TUBERKULOSE_IMPFSTOFF("836402002",
+                          "2.16.840.1.113883.6.96",
+                          "Tuberkulose Impfstoff",
+                          "Tuberkulose Impfstoff",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Typhus Impfstoff.<br>
+     */
+    TYPHUS_IMPFSTOFF("836390004",
+                     "2.16.840.1.113883.6.96",
+                     "Typhus Impfstoff",
+                     "Typhus Impfstoff",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Varizellen AK qn.<br>
+     */
+    VARIZELLEN_AK_QN_L1("8046-5",
+                        "2.16.840.1.113883.6.1",
+                        "Varizellen AK qn.",
+                        "Varizellen AK qn.",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Varizellen Impfstoff.<br>
+     */
+    VARIZELLEN_IMPFSTOFF("836495005",
+                         "2.16.840.1.113883.6.96",
+                         "Varizellen Impfstoff",
+                         "Varizellen Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE");
+
+    /**
+     * EN: Code for aP AK qn.<br>
+     */
+    public static final String AP_AK_QN_L1_CODE = "11585-7";
+
+    /**
+     * EN: Code for Cholera AK qn.<br>
+     */
+    public static final String CHOLERA_AK_QN_L1_CODE = "31698-4";
+
+    /**
+     * EN: Code for Cholera Impfstoff.<br>
+     */
+    public static final String CHOLERA_IMPFSTOFF_CODE = "836383009";
+
+    /**
+     * EN: Code for Covid-19 Impfstoff.<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_CODE = "840534001";
+
+    /**
+     * EN: Code for Diphtherie Impfstoff.<br>
+     */
+    public static final String DIPHTHERIE_IMPFSTOFF_CODE = "836381006";
+
+    /**
+     * EN: Code for Di AK qn.<br>
+     */
+    public static final String DI_AK_QN_L1_CODE = "5115-1";
+
+    /**
+     * EN: Code for Frühsommer-Meningoenzephalitis Impfstoff.<br>
+     */
+    public static final String FR_HSOMMER_MENINGOENZEPHALITIS_IMPFSTOFF_CODE = "836403007";
+
+    /**
+     * EN: Code for FSME AK qn.<br>
+     */
+    public static final String FSME_AK_QN_L1_CODE = "31383-3";
+
+    /**
+     * EN: Code for Gelbfieber Impfstoff.<br>
+     */
+    public static final String GELBFIEBER_IMPFSTOFF_CODE = "836385002";
+
+    /**
+     * EN: Code for Haemophilus influenzae Typ B Impfstoff.<br>
+     */
+    public static final String HAEMOPHILUS_INFLUENZAE_TYP_B_IMPFSTOFF_CODE = "836380007";
+
+    /**
+     * EN: Code for HAV AK qn.<br>
+     */
+    public static final String HAV_AK_QN_L1_CODE = "22312-3";
+
+    /**
+     * EN: Code for HBV s-AK qn.<br>
+     */
+    public static final String HBV_S_AK_QN_L1_CODE = "16935-9";
+
+    /**
+     * EN: Code for Hepatitis A Impfstoff.<br>
+     */
+    public static final String HEPATITIS_A_IMPFSTOFF_CODE = "836375003";
+
+    /**
+     * EN: Code for Hepatitis B Impfstoff.<br>
+     */
+    public static final String HEPATITIS_B_IMPFSTOFF_CODE = "836374004";
+
+    /**
+     * EN: Code for Herpes Zoster Impfstoff.<br>
+     */
+    public static final String HERPES_ZOSTER_IMPFSTOFF_CODE = "871919004";
+
+    /**
+     * EN: Code for HiB AK qn.<br>
+     */
+    public static final String HIB_AK_QN_L1_CODE = "7931-9";
+
+    /**
+     * EN: Code for Humane Papillomaviren Impfstoff.<br>
+     */
+    public static final String HUMANE_PAPILLOMAVIREN_IMPFSTOFF_CODE = "836379009";
+
+    /**
+     * EN: Code for Influenza A AK qn.<br>
+     */
+    public static final String INFLUENZA_A_AK_QN_L1_CODE = "7920-2";
+
+    /**
+     * EN: Code for Influenza (H1N1) Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H1N1_IMPFSTOFF_CODE = "871772009";
+
+    /**
+     * EN: Code for Influenza (H5N1) Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H5N1_IMPFSTOFF_CODE = "427036009";
+
+    /**
+     * EN: Code for Influenza H5 AK Ti.<br>
+     */
+    public static final String INFLUENZA_H5_AK_TI_L1_CODE = "47454-4";
+
+    /**
+     * EN: Code for Influenza Impfstoff.<br>
+     */
+    public static final String INFLUENZA_IMPFSTOFF_CODE = "836377006";
+
+    /**
+     * EN: Code for Japanische Enzephalitis Impfstoff.<br>
+     */
+    public static final String JAPANISCHE_ENZEPHALITIS_IMPFSTOFF_CODE = "836378001";
+
+    /**
+     * EN: Code for Masern AK qn.<br>
+     */
+    public static final String MASERN_AK_QN_L1_CODE = "7961-6";
+
+    /**
+     * EN: Code for Masern Impfstoff.<br>
+     */
+    public static final String MASERN_IMPFSTOFF_CODE = "836382004";
+
+    /**
+     * EN: Code for Meningokokken Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_IMPFSTOFF_CODE = "836401009";
+
+    /**
+     * EN: Code for Meningokokken Serotyp B Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_B_IMPFSTOFF_CODE = "1981000221108";
+
+    /**
+     * EN: Code for Meningokokken Serotyp C Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_C_IMPFSTOFF_CODE = "871866001";
+
+    /**
+     * EN: Code for Mpox/Pocken Impfstoff.<br>
+     */
+    public static final String MPOX_POCKEN_IMPFSTOFF_CODE = "836389008";
+
+    /**
+     * EN: Code for Mumps AK qn.<br>
+     */
+    public static final String MUMPS_AK_QN_L1_CODE = "7965-7";
+
+    /**
+     * EN: Code for Mumps Impfstoff.<br>
+     */
+    public static final String MUMPS_IMPFSTOFF_CODE = "871738001";
+
+    /**
+     * EN: Code for Pertussis Impfstoff.<br>
+     */
+    public static final String PERTUSSIS_IMPFSTOFF_CODE = "601000221108";
+
+    /**
+     * EN: Code for Pneumokokken Impfstoff.<br>
+     */
+    public static final String PNEUMOKOKKEN_IMPFSTOFF_CODE = "836398006";
+
+    /**
+     * EN: Code for Poliomyelitis Impfstoff.<br>
+     */
+    public static final String POLIOMYELITIS_IMPFSTOFF_CODE = "1031000221108";
+
+    /**
+     * EN: Code for Polio AK qn.<br>
+     */
+    public static final String POLIO_AK_QN_L1_CODE = "16284-2";
+
+    /**
+     * EN: Code for Polio virus 1 Ab.<br>
+     */
+    public static final String POLIO_VIRUS_1_AB_L1_CODE = "5281-1";
+
+    /**
+     * EN: Code for Polio virus 2 Ab.<br>
+     */
+    public static final String POLIO_VIRUS_2_AB_L1_CODE = "5283-7";
+
+    /**
+     * EN: Code for Polio virus 3 Ab.<br>
+     */
+    public static final String POLIO_VIRUS_3_AB_L1_CODE = "5285-2";
+
+    /**
+     * EN: Code for Rabies virus Ab.<br>
+     */
+    public static final String RABIES_VIRUS_AB_L1_CODE = "6524-3";
+
+    /**
+     * EN: Code for Rotavirus Impfstoff.<br>
+     */
+    public static final String ROTAVIRUS_IMPFSTOFF_CODE = "836387005";
+
+    /**
+     * EN: Code for Rota AK qn.<br>
+     */
+    public static final String ROTA_AK_QN_L1_CODE = "5328-0";
+
+    /**
+     * EN: Code for Röteln Ab Tutr Ser HAI.<br>
+     */
+    public static final String R_TELN_AB_TUTR_SER_HAI_L1_CODE = "50694-9";
+
+    /**
+     * EN: Code for Röteln AK qn.<br>
+     */
+    public static final String R_TELN_AK_QN_L1_CODE = "8013-5";
+
+    /**
+     * EN: Code for Röteln IgG AK Ti.<br>
+     */
+    public static final String R_TELN_IGG_AK_TI_L1_CODE = "41763-4";
+
+    /**
+     * EN: Code for Röteln Impfstoff.<br>
+     */
+    public static final String R_TELN_IMPFSTOFF_CODE = "836388000";
+
+    /**
+     * EN: Code for SARS-CoV-2-AK IgG.<br>
+     */
+    public static final String SARS_COV_2_AK_IGG_L1_CODE = "94505-5";
+
+    /**
+     * EN: Code for SARS-CoV-2-AK IgG ql.<br>
+     */
+    public static final String SARS_COV_2_AK_IGG_QL_L1_CODE = "94563-4";
+
+    /**
+     * EN: Code for SARS-CoV-2-AK IgG ST.<br>
+     */
+    public static final String SARS_COV_2_AK_IGG_ST_L1_CODE = "94507-1";
+
+    /**
+     * EN: Code for SARS-CoV-2-AK ql.<br>
+     */
+    public static final String SARS_COV_2_AK_QL_L1_CODE = "94547-7";
+
+    /**
+     * EN: Code for Tetanustoxin AK qn.<br>
+     */
+    public static final String TETANUSTOXIN_AK_QN_L1_CODE = "32775-9";
+
+    /**
+     * EN: Code for Tetanus Impfstoff.<br>
+     */
+    public static final String TETANUS_IMPFSTOFF_CODE = "1101000221104";
+
+    /**
+     * EN: Code for Tollwut AK qn.<br>
+     */
+    public static final String TOLLWUT_AK_QN_L1_CODE = "5288-6";
+
+    /**
+     * EN: Code for Tollwut Impfstoff.<br>
+     */
+    public static final String TOLLWUT_IMPFSTOFF_CODE = "836393002";
+
+    /**
+     * EN: Code for Tuberkulose Impfstoff.<br>
+     */
+    public static final String TUBERKULOSE_IMPFSTOFF_CODE = "836402002";
+
+    /**
+     * EN: Code for Typhus Impfstoff.<br>
+     */
+    public static final String TYPHUS_IMPFSTOFF_CODE = "836390004";
+
+    /**
+     * EN: Code for Varizellen AK qn.<br>
+     */
+    public static final String VARIZELLEN_AK_QN_L1_CODE = "8046-5";
+
+    /**
+     * EN: Code for Varizellen Impfstoff.<br>
+     */
+    public static final String VARIZELLEN_IMPFSTOFF_CODE = "836495005";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.13";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = " eimpf-antikoerperbestimmung";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "2.16.840.1.113883.6.96";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfAntikoerperbestimmung getEnum(@Nullable final String code) {
+        for (final EimpfAntikoerperbestimmung x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfAntikoerperbestimmung.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfAntikoerperbestimmung x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfAntikoerperbestimmung(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfHistorischeimpfstoffe.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfHistorischeimpfstoffe.java
@@ -839,8 +839,8 @@ public enum EimpfHistorischeimpfstoffe implements ValueSetEnumInterface {
      */
     POLIO_SABIN_ORAL_SB_TROPFEN_UND_ZUCKERSUSPENSION("AHI073",
                                                      "1.2.40.0.34.5.186",
-                                                     "Polio Sabin (oral) "SB" - Tropfen und Zuckersuspension",
-                                                     "Polio Sabin (oral) "SB" - Tropfen und Zuckersuspension",
+                                                     "Polio Sabin (oral) \"SB\" - Tropfen und Zuckersuspension",
+                                                     "Polio Sabin (oral) \"SB\" - Tropfen und Zuckersuspension",
                                                      "TOTRANSLATE",
                                                      "TOTRANSLATE",
                                                      "TOTRANSLATE"),

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfHistorischeimpfstoffe.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfHistorischeimpfstoffe.java
@@ -1,0 +1,2238 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-historischeimpfstoffe values
+ * <p>
+ * EN: No designation found.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.10<br>
+ * Effective date: 2023-08-29 00:00<br>
+ * Version: 2.1.0+20230829(-beta)<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfHistorischeimpfstoffe implements ValueSetEnumInterface {
+
+    /**
+     * EN: Acel - P Lederle.<br>
+     */
+    ACEL_P_LEDERLE("AHI001",
+                   "1.2.40.0.34.5.186",
+                   "Acel - P Lederle",
+                   "Acel - P Lederle",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Act-HIB+DPT.<br>
+     */
+    ACT_HIB_DPT("AHI002",
+                "1.2.40.0.34.5.186",
+                "Act-HIB+DPT",
+                "Act-HIB+DPT",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Addigrip.<br>
+     */
+    ADDIGRIP("AHI003",
+             "1.2.40.0.34.5.186",
+             "Addigrip",
+             "Addigrip",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Arepanrix.<br>
+     */
+    AREPANRIX("AHI004",
+              "1.2.40.0.34.5.186",
+              "Arepanrix",
+              "Arepanrix",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Arilvax.<br>
+     */
+    ARILVAX("AHI005",
+            "1.2.40.0.34.5.186",
+            "Arilvax",
+            "Arilvax",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Avaxim.<br>
+     */
+    AVAXIM("AHI130",
+           "1.2.40.0.34.5.186",
+           "Avaxim",
+           "Avaxim",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Batrevac.<br>
+     */
+    BATREVAC("AHI006",
+             "1.2.40.0.34.5.186",
+             "Batrevac",
+             "Batrevac",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: BCG Vaccine 'Mérieux'.<br>
+     */
+    BCG_VACCINE_M_RIEUX("AHI007",
+                        "1.2.40.0.34.5.186",
+                        "BCG Vaccine 'Mérieux'",
+                        "BCG Vaccine 'Mérieux'",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Begrivac.<br>
+     */
+    BEGRIVAC("AHI008",
+             "1.2.40.0.34.5.186",
+             "Begrivac",
+             "Begrivac",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Celvapan.<br>
+     */
+    CELVAPAN("AHI009",
+             "1.2.40.0.34.5.186",
+             "Celvapan",
+             "Celvapan",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Cholera - Impfstoff 'Berna'.<br>
+     */
+    CHOLERA_IMPFSTOFF_BERNA("AHI010",
+                            "1.2.40.0.34.5.186",
+                            "Cholera - Impfstoff 'Berna'",
+                            "Cholera - Impfstoff 'Berna'",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Cholera - Vakzine 'Sero'.<br>
+     */
+    CHOLERA_VAKZINE_SERO("AHI011",
+                         "1.2.40.0.34.5.186",
+                         "Cholera - Vakzine 'Sero'",
+                         "Cholera - Vakzine 'Sero'",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Daronrix.<br>
+     */
+    DARONRIX("AHI012",
+             "1.2.40.0.34.5.186",
+             "Daronrix",
+             "Daronrix",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Diftetall.<br>
+     */
+    DIFTETALL("AHI013",
+              "1.2.40.0.34.5.186",
+              "Diftetall",
+              "Diftetall",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie Adsorbat Impfstoff 'Behring'.<br>
+     */
+    DIPHTHERIE_ADSORBAT_IMPFSTOFF_BEHRING("AHI014",
+                                          "1.2.40.0.34.5.186",
+                                          "Diphtherie Adsorbat Impfstoff 'Behring'",
+                                          "Diphtherie Adsorbat Impfstoff 'Behring'",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Ditanrix.<br>
+     */
+    DITANRIX("AHI015",
+             "1.2.40.0.34.5.186",
+             "Ditanrix",
+             "Ditanrix",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: DiTePer Anatoxal Berna.<br>
+     */
+    DITEPER_ANATOXAL_BERNA("AHI018",
+                           "1.2.40.0.34.5.186",
+                           "DiTePer Anatoxal Berna",
+                           "DiTePer Anatoxal Berna",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: DiTe Anatoxal Berna.<br>
+     */
+    DITE_ANATOXAL_BERNA("AHI016",
+                        "1.2.40.0.34.5.186",
+                        "DiTe Anatoxal Berna",
+                        "DiTe Anatoxal Berna",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: DiTe Anatoxal(dT) Berna.<br>
+     */
+    DITE_ANATOXAL_DT_BERNA("AHI017",
+                           "1.2.40.0.34.5.186",
+                           "DiTe Anatoxal(dT) Berna",
+                           "DiTe Anatoxal(dT) Berna",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: DPT Adsorbat 'Mérieux'.<br>
+     */
+    DPT_ADSORBAT_M_RIEUX("AHI020",
+                         "1.2.40.0.34.5.186",
+                         "DPT Adsorbat 'Mérieux'",
+                         "DPT Adsorbat 'Mérieux'",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: DTaP Vakzine SSI.<br>
+     */
+    DTAP_VAKZINE_SSI("AHI021",
+                     "1.2.40.0.34.5.186",
+                     "DTaP Vakzine SSI",
+                     "DTaP Vakzine SSI",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: DT Adsorbat 'Mérieux'.<br>
+     */
+    DT_ADSORBAT_M_RIEUX("AHI019",
+                        "1.2.40.0.34.5.186",
+                        "DT Adsorbat 'Mérieux'",
+                        "DT Adsorbat 'Mérieux'",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: D.T.Vax.<br>
+     */
+    D_T_VAX("AHI022",
+            "1.2.40.0.34.5.186",
+            "D.T.Vax",
+            "D.T.Vax",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Epaxal.<br>
+     */
+    EPAXAL("AHI023",
+           "1.2.40.0.34.5.186",
+           "Epaxal",
+           "Epaxal",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Ervevax.<br>
+     */
+    ERVEVAX("AHI024",
+            "1.2.40.0.34.5.186",
+            "Ervevax",
+            "Ervevax",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Fluad.<br>
+     */
+    FLUAD("AHI131",
+          "1.2.40.0.34.5.186",
+          "Fluad",
+          "Fluad",
+          "TOTRANSLATE",
+          "TOTRANSLATE",
+          "TOTRANSLATE"),
+    /**
+     * EN: Fluarix.<br>
+     */
+    FLUARIX("AHI025",
+            "1.2.40.0.34.5.186",
+            "Fluarix",
+            "Fluarix",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Fluenz.<br>
+     */
+    FLUENZ("AHI026",
+           "1.2.40.0.34.5.186",
+           "Fluenz",
+           "Fluenz",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Fluvaccinol Subunit.<br>
+     */
+    FLUVACCINOL_SUBUNIT("AHI127",
+                        "1.2.40.0.34.5.186",
+                        "Fluvaccinol Subunit",
+                        "Fluvaccinol Subunit",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Fluvirin.<br>
+     */
+    FLUVIRIN("AHI027",
+             "1.2.40.0.34.5.186",
+             "Fluvirin",
+             "Fluvirin",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Focetria.<br>
+     */
+    FOCETRIA("AHI028",
+             "1.2.40.0.34.5.186",
+             "Focetria",
+             "Focetria",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Gen-HB-vax 10 ug.<br>
+     */
+    GEN_HB_VAX_10_UG("AHI029",
+                     "1.2.40.0.34.5.186",
+                     "Gen-HB-vax 10 ug",
+                     "Gen-HB-vax 10 ug",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Havrix 360 E.I.U./ml.<br>
+     */
+    HAVRIX_360_E_I_U_ML("AHI030",
+                        "1.2.40.0.34.5.186",
+                        "Havrix 360 E.I.U./ml",
+                        "Havrix 360 E.I.U./ml",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Hepacare.<br>
+     */
+    HEPACARE("AHI031",
+             "1.2.40.0.34.5.186",
+             "Hepacare",
+             "Hepacare",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Hepatyrix.<br>
+     */
+    HEPATYRIX("AHI032",
+              "1.2.40.0.34.5.186",
+              "Hepatyrix",
+              "Hepatyrix",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Hevac B 'Pasteur'.<br>
+     */
+    HEVAC_B_PASTEUR("AHI033",
+                    "1.2.40.0.34.5.186",
+                    "Hevac B 'Pasteur'",
+                    "Hevac B 'Pasteur'",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Hexavac.<br>
+     */
+    HEXAVAC("AHI034",
+            "1.2.40.0.34.5.186",
+            "Hexavac",
+            "Hexavac",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Hiberix.<br>
+     */
+    HIBERIX("AHI036",
+            "1.2.40.0.34.5.186",
+            "Hiberix",
+            "Hiberix",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: HIB-Titer.<br>
+     */
+    HIB_TITER("AHI035",
+              "1.2.40.0.34.5.186",
+              "HIB-Titer",
+              "HIB-Titer",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Humenza.<br>
+     */
+    HUMENZA("AHI037",
+            "1.2.40.0.34.5.186",
+            "Humenza",
+            "Humenza",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: IDflu.<br>
+     */
+    IDFLU("AHI038",
+          "1.2.40.0.34.5.186",
+          "IDflu",
+          "IDflu",
+          "TOTRANSLATE",
+          "TOTRANSLATE",
+          "TOTRANSLATE"),
+    /**
+     * EN: Immovax Polio.<br>
+     */
+    IMMOVAX_POLIO("AHI040",
+                  "1.2.40.0.34.5.186",
+                  "Immovax Polio",
+                  "Immovax Polio",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Immugrip.<br>
+     */
+    IMMUGRIP("AHI039",
+             "1.2.40.0.34.5.186",
+             "Immugrip",
+             "Immugrip",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Infanrix.<br>
+     */
+    INFANRIX("AHI041",
+             "1.2.40.0.34.5.186",
+             "Infanrix",
+             "Infanrix",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Infanrix + HepB.<br>
+     */
+    INFANRIX_HEPB("AHI044",
+                  "1.2.40.0.34.5.186",
+                  "Infanrix + HepB",
+                  "Infanrix + HepB",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Infanrix + HiB.<br>
+     */
+    INFANRIX_HIB("AHI045",
+                 "1.2.40.0.34.5.186",
+                 "Infanrix + HiB",
+                 "Infanrix + HiB",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Infanrix Penta.<br>
+     */
+    INFANRIX_PENTA("AHI042",
+                   "1.2.40.0.34.5.186",
+                   "Infanrix Penta",
+                   "Infanrix Penta",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Infanrix Tetra.<br>
+     */
+    INFANRIX_TETRA("AHI043",
+                   "1.2.40.0.34.5.186",
+                   "Infanrix Tetra",
+                   "Infanrix Tetra",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Inflexal V.<br>
+     */
+    INFLEXAL_V("AHI046",
+               "1.2.40.0.34.5.186",
+               "Inflexal V",
+               "Inflexal V",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Influvac.<br>
+     */
+    INFLUVAC("AHI135",
+             "1.2.40.0.34.5.186",
+             "Influvac",
+             "Influvac",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Intanza.<br>
+     */
+    INTANZA("AHI047",
+            "1.2.40.0.34.5.186",
+            "Intanza",
+            "Intanza",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Invivac.<br>
+     */
+    INVIVAC("AHI048",
+            "1.2.40.0.34.5.186",
+            "Invivac",
+            "Invivac",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: IPV Mérieux.<br>
+     */
+    IPV_M_RIEUX("AHI049",
+                "1.2.40.0.34.5.186",
+                "IPV Mérieux",
+                "IPV Mérieux",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Japan B Encephalitis Vaccine.<br>
+     */
+    JAPAN_B_ENCEPHALITIS_VACCINE("AHI051",
+                                 "1.2.40.0.34.5.186",
+                                 "Japan B Encephalitis Vaccine",
+                                 "Japan B Encephalitis Vaccine",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: JE - Vax.<br>
+     */
+    JE_VAX("AHI050",
+           "1.2.40.0.34.5.186",
+           "JE - Vax",
+           "JE - Vax",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Laevactin.<br>
+     */
+    LAEVACTIN("AHI052",
+              "1.2.40.0.34.5.186",
+              "Laevactin",
+              "Laevactin",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Masern Vaccine 'Mérieux'.<br>
+     */
+    MASERN_VACCINE_M_RIEUX("AHI053",
+                           "1.2.40.0.34.5.186",
+                           "Masern Vaccine 'Mérieux'",
+                           "Masern Vaccine 'Mérieux'",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Menactra.<br>
+     */
+    MENACTRA("AHI059",
+             "1.2.40.0.34.5.186",
+             "Menactra",
+             "Menactra",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Mencevax ACWY.<br>
+     */
+    MENCEVAX_ACWY("AHI057",
+                  "1.2.40.0.34.5.186",
+                  "Mencevax ACWY",
+                  "Mencevax ACWY",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken-Impfstoff A+C Mérieux.<br>
+     */
+    MENINGOKOKKEN_IMPFSTOFF_A_C_M_RIEUX("AHI060",
+                                        "1.2.40.0.34.5.186",
+                                        "Meningokokken-Impfstoff A+C Mérieux",
+                                        "Meningokokken-Impfstoff A+C Mérieux",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE"),
+    /**
+     * EN: Meningovax A+C.<br>
+     */
+    MENINGOVAX_A_C("AHI058",
+                   "1.2.40.0.34.5.186",
+                   "Meningovax A+C",
+                   "Meningovax A+C",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Meninvact C.<br>
+     */
+    MENINVACT_C("AHI061",
+                "1.2.40.0.34.5.186",
+                "Meninvact C",
+                "Meninvact C",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Menjugate.<br>
+     */
+    MENJUGATE("AHI134",
+              "1.2.40.0.34.5.186",
+              "Menjugate",
+              "Menjugate",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Menomune ACWY.<br>
+     */
+    MENOMUNE_ACWY("AHI054",
+                  "1.2.40.0.34.5.186",
+                  "Menomune ACWY",
+                  "Menomune ACWY",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: MMR Triplovax.<br>
+     */
+    MMR_TRIPLOVAX("AHI056",
+                  "1.2.40.0.34.5.186",
+                  "MMR Triplovax",
+                  "MMR Triplovax",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Mumps Vaccine 'Merieux'.<br>
+     */
+    MUMPS_VACCINE_MERIEUX("AHI055",
+                          "1.2.40.0.34.5.186",
+                          "Mumps Vaccine 'Merieux'",
+                          "Mumps Vaccine 'Merieux'",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Mutagrip.<br>
+     */
+    MUTAGRIP("AHI062",
+             "1.2.40.0.34.5.186",
+             "Mutagrip",
+             "Mutagrip",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Optaflu.<br>
+     */
+    OPTAFLU("AHI063",
+            "1.2.40.0.34.5.186",
+            "Optaflu",
+            "Optaflu",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Orochol.<br>
+     */
+    OROCHOL("AHI064",
+            "1.2.40.0.34.5.186",
+            "Orochol",
+            "Orochol",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: PAC-Mérieux.<br>
+     */
+    PAC_M_RIEUX("AHI065",
+                "1.2.40.0.34.5.186",
+                "PAC-Mérieux",
+                "PAC-Mérieux",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Pandemrix.<br>
+     */
+    PANDEMRIX("AHI066",
+              "1.2.40.0.34.5.186",
+              "Pandemrix",
+              "Pandemrix",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Pariorix.<br>
+     */
+    PARIORIX("AHI067",
+             "1.2.40.0.34.5.186",
+             "Pariorix",
+             "Pariorix",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Pediacel.<br>
+     */
+    PEDIACEL("AHI068",
+             "1.2.40.0.34.5.186",
+             "Pediacel",
+             "Pediacel",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Pentavac.<br>
+     */
+    PENTAVAC("AHI070",
+             "1.2.40.0.34.5.186",
+             "Pentavac",
+             "Pentavac",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Pent-Act-HiB.<br>
+     */
+    PENT_ACT_HIB("AHI069",
+                 "1.2.40.0.34.5.186",
+                 "Pent-Act-HiB",
+                 "Pent-Act-HiB",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Pertoral.<br>
+     */
+    PERTORAL("AHI071",
+             "1.2.40.0.34.5.186",
+             "Pertoral",
+             "Pertoral",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Pneumo 23 'Merieux'.<br>
+     */
+    PNEUMO_23_MERIEUX("AHI075",
+                      "1.2.40.0.34.5.186",
+                      "Pneumo 23 'Merieux'",
+                      "Pneumo 23 'Merieux'",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: PNU-Imune.<br>
+     */
+    PNU_IMUNE("AHI076",
+              "1.2.40.0.34.5.186",
+              "PNU-Imune",
+              "PNU-Imune",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Pocken Vaccine.<br>
+     */
+    POCKEN_VACCINE("AHI072",
+                   "1.2.40.0.34.5.186",
+                   "Pocken Vaccine",
+                   "Pocken Vaccine",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Poliomyelitis Vaccine 'Berna'.<br>
+     */
+    POLIOMYELITIS_VACCINE_BERNA("AHI074",
+                                "1.2.40.0.34.5.186",
+                                "Poliomyelitis Vaccine 'Berna'",
+                                "Poliomyelitis Vaccine 'Berna'",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Polio Sabin (oral) "SB" - Tropfen und Zuckersuspension.<br>
+     */
+    POLIO_SABIN_ORAL_SB_TROPFEN_UND_ZUCKERSUSPENSION("AHI073",
+                                                     "1.2.40.0.34.5.186",
+                                                     "Polio Sabin (oral) "SB" - Tropfen und Zuckersuspension",
+                                                     "Polio Sabin (oral) "SB" - Tropfen und Zuckersuspension",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE"),
+    /**
+     * EN: Preflucel.<br>
+     */
+    PREFLUCEL("AHI124",
+              "1.2.40.0.34.5.186",
+              "Preflucel",
+              "Preflucel",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Prepandrix.<br>
+     */
+    PREPANDRIX("AHI132",
+               "1.2.40.0.34.5.186",
+               "Prepandrix",
+               "Prepandrix",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Prevenar (7-valent).<br>
+     */
+    PREVENAR_7_VALENT("AHI080",
+                      "1.2.40.0.34.5.186",
+                      "Prevenar (7-valent)",
+                      "Prevenar (7-valent)",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Primavax.<br>
+     */
+    PRIMAVAX("AHI081",
+             "1.2.40.0.34.5.186",
+             "Primavax",
+             "Primavax",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Procomvax.<br>
+     */
+    PROCOMVAX("AHI082",
+              "1.2.40.0.34.5.186",
+              "Procomvax",
+              "Procomvax",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: ProHIBiT.<br>
+     */
+    PROHIBIT("AHI084",
+             "1.2.40.0.34.5.186",
+             "ProHIBiT",
+             "ProHIBiT",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Provarivax.<br>
+     */
+    PROVARIVAX("AHI083",
+               "1.2.40.0.34.5.186",
+               "Provarivax",
+               "Provarivax",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Präpandemischer Impfstoff (H5N1) GSK.<br>
+     */
+    PR_PANDEMISCHER_IMPFSTOFF_H5N1_GSK("AHI077",
+                                       "1.2.40.0.34.5.186",
+                                       "Präpandemischer Impfstoff (H5N1) GSK",
+                                       "Präpandemischer Impfstoff (H5N1) GSK",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE"),
+    /**
+     * EN: Präpandemischer Impfstoff (H5N1) Novartis.<br>
+     */
+    PR_PANDEMISCHER_IMPFSTOFF_H5N1_NOVARTIS("AHI078",
+                                            "1.2.40.0.34.5.186",
+                                            "Präpandemischer Impfstoff (H5N1) Novartis",
+                                            "Präpandemischer Impfstoff (H5N1) Novartis",
+                                            "TOTRANSLATE",
+                                            "TOTRANSLATE",
+                                            "TOTRANSLATE"),
+    /**
+     * EN: Prévigrip.<br>
+     */
+    PR_VIGRIP("AHI079",
+              "1.2.40.0.34.5.186",
+              "Prévigrip",
+              "Prévigrip",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Pumarix.<br>
+     */
+    PUMARIX("AHI085",
+            "1.2.40.0.34.5.186",
+            "Pumarix",
+            "Pumarix",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Quatrovirelon.<br>
+     */
+    QUATROVIRELON("AHI086",
+                  "1.2.40.0.34.5.186",
+                  "Quatrovirelon",
+                  "Quatrovirelon",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Quintanrix.<br>
+     */
+    QUINTANRIX("AHI087",
+               "1.2.40.0.34.5.186",
+               "Quintanrix",
+               "Quintanrix",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Quintovirelon.<br>
+     */
+    QUINTOVIRELON("AHI088",
+                  "1.2.40.0.34.5.186",
+                  "Quintovirelon",
+                  "Quintovirelon",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Rabies Imovax.<br>
+     */
+    RABIES_IMOVAX("AHI089",
+                  "1.2.40.0.34.5.186",
+                  "Rabies Imovax",
+                  "Rabies Imovax",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Rimevax.<br>
+     */
+    RIMEVAX("AHI091",
+            "1.2.40.0.34.5.186",
+            "Rimevax",
+            "Rimevax",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Rimparix.<br>
+     */
+    RIMPARIX("AHI090",
+             "1.2.40.0.34.5.186",
+             "Rimparix",
+             "Rimparix",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: RotaShield.<br>
+     */
+    ROTASHIELD("AHI094",
+               "1.2.40.0.34.5.186",
+               "RotaShield",
+               "RotaShield",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Rouvax.<br>
+     */
+    ROUVAX("AHI092",
+           "1.2.40.0.34.5.186",
+           "Rouvax",
+           "Rouvax",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Rubeaten 'Berna'.<br>
+     */
+    RUBEATEN_BERNA("AHI096",
+                   "1.2.40.0.34.5.186",
+                   "Rubeaten 'Berna'",
+                   "Rubeaten 'Berna'",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Rudivax.<br>
+     */
+    RUDIVAX("AHI093",
+            "1.2.40.0.34.5.186",
+            "Rudivax",
+            "Rudivax",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Röteln-Impfstoff HDC Mérieux.<br>
+     */
+    R_TELN_IMPFSTOFF_HDC_M_RIEUX("AHI095",
+                                 "1.2.40.0.34.5.186",
+                                 "Röteln-Impfstoff HDC Mérieux",
+                                 "Röteln-Impfstoff HDC Mérieux",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Sandovac.<br>
+     */
+    SANDOVAC("AHI125",
+             "1.2.40.0.34.5.186",
+             "Sandovac",
+             "Sandovac",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Silgard.<br>
+     */
+    SILGARD("AHI128",
+            "1.2.40.0.34.5.186",
+            "Silgard",
+            "Silgard",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Spirolept.<br>
+     */
+    SPIROLEPT("AHI097",
+              "1.2.40.0.34.5.186",
+              "Spirolept",
+              "Spirolept",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Tanrix.<br>
+     */
+    TANRIX("AHI098",
+           "1.2.40.0.34.5.186",
+           "Tanrix",
+           "Tanrix",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Td-Rix.<br>
+     */
+    TD_RIX("AHI102",
+           "1.2.40.0.34.5.186",
+           "Td-Rix",
+           "Td-Rix",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Tetagrip.<br>
+     */
+    TETAGRIP("AHI103",
+             "1.2.40.0.34.5.186",
+             "Tetagrip",
+             "Tetagrip",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Tetanol.<br>
+     */
+    TETANOL("AHI100",
+            "1.2.40.0.34.5.186",
+            "Tetanol",
+            "Tetanol",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Tetanus-Adsorbat 'Merieux'.<br>
+     */
+    TETANUS_ADSORBAT_MERIEUX("AHI101",
+                             "1.2.40.0.34.5.186",
+                             "Tetanus-Adsorbat 'Merieux'",
+                             "Tetanus-Adsorbat 'Merieux'",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Tetracoq.<br>
+     */
+    TETRACOQ("AHI104",
+             "1.2.40.0.34.5.186",
+             "Tetracoq",
+             "Tetracoq",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Tetravac.<br>
+     */
+    TETRAVAC("AHI133",
+             "1.2.40.0.34.5.186",
+             "Tetravac",
+             "Tetravac",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Te-Anatoxal 'Berna'.<br>
+     */
+    TE_ANATOXAL_BERNA("AHI099",
+                      "1.2.40.0.34.5.186",
+                      "Te-Anatoxal 'Berna'",
+                      "Te-Anatoxal 'Berna'",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Ticovac.<br>
+     */
+    TICOVAC("AHI108",
+            "1.2.40.0.34.5.186",
+            "Ticovac",
+            "Ticovac",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Ticovac junior.<br>
+     */
+    TICOVAC_JUNIOR("AHI107",
+                   "1.2.40.0.34.5.186",
+                   "Ticovac junior",
+                   "Ticovac junior",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Vaccine HDC.<br>
+     */
+    TOLLWUT_VACCINE_HDC("AHI111",
+                        "1.2.40.0.34.5.186",
+                        "Tollwut Vaccine HDC",
+                        "Tollwut Vaccine HDC",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Vakzine 'Pasteur Merieux'.<br>
+     */
+    TOLLWUT_VAKZINE_PASTEUR_MERIEUX("AHI109",
+                                    "1.2.40.0.34.5.186",
+                                    "Tollwut Vakzine 'Pasteur Merieux'",
+                                    "Tollwut Vakzine 'Pasteur Merieux'",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE"),
+    /**
+     * EN: Triacelluvax.<br>
+     */
+    TRIACELLUVAX("AHI105",
+                 "1.2.40.0.34.5.186",
+                 "Triacelluvax",
+                 "Triacelluvax",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Triaxis Polio.<br>
+     */
+    TRIAXIS_POLIO("AHI106",
+                  "1.2.40.0.34.5.186",
+                  "Triaxis Polio",
+                  "Triaxis Polio",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Tritanrix DTPw.<br>
+     */
+    TRITANRIX_DTPW("AHI110",
+                   "1.2.40.0.34.5.186",
+                   "Tritanrix DTPw",
+                   "Tritanrix DTPw",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Tritanrix HepB.<br>
+     */
+    TRITANRIX_HEPB("AHI112",
+                   "1.2.40.0.34.5.186",
+                   "Tritanrix HepB",
+                   "Tritanrix HepB",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Tyavax.<br>
+     */
+    TYAVAX("AHI113",
+           "1.2.40.0.34.5.186",
+           "Tyavax",
+           "Tyavax",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Typherix.<br>
+     */
+    TYPHERIX("AHI114",
+             "1.2.40.0.34.5.186",
+             "Typherix",
+             "Typherix",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Typhoral.<br>
+     */
+    TYPHORAL("AHI115",
+             "1.2.40.0.34.5.186",
+             "Typhoral",
+             "Typhoral",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Vaccine Boostrixtetra.<br>
+     */
+    VACCINE_BOOSTRIXTETRA("AHI120",
+                          "1.2.40.0.34.5.186",
+                          "Vaccine Boostrixtetra",
+                          "Vaccine Boostrixtetra",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Vaccine Rabique Pasteur.<br>
+     */
+    VACCINE_RABIQUE_PASTEUR("AHI118",
+                            "1.2.40.0.34.5.186",
+                            "Vaccine Rabique Pasteur",
+                            "Vaccine Rabique Pasteur",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Vaccine Tétamique Pasteur.<br>
+     */
+    VACCINE_T_TAMIQUE_PASTEUR("AHI119",
+                              "1.2.40.0.34.5.186",
+                              "Vaccine Tétamique Pasteur",
+                              "Vaccine Tétamique Pasteur",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Vaccin GenHevac B Pasteur.<br>
+     */
+    VACCIN_GENHEVAC_B_PASTEUR("AHI117",
+                              "1.2.40.0.34.5.186",
+                              "Vaccin GenHevac B Pasteur",
+                              "Vaccin GenHevac B Pasteur",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Vaccin Rabique inactivé Mérieux HDCV.<br>
+     */
+    VACCIN_RABIQUE_INACTIV_M_RIEUX_HDCV("AHI116",
+                                        "1.2.40.0.34.5.186",
+                                        "Vaccin Rabique inactivé Mérieux HDCV",
+                                        "Vaccin Rabique inactivé Mérieux HDCV",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE"),
+    /**
+     * EN: Varicella Impfstoff SB.<br>
+     */
+    VARICELLA_IMPFSTOFF_SB("AHI121",
+                           "1.2.40.0.34.5.186",
+                           "Varicella Impfstoff SB",
+                           "Varicella Impfstoff SB",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Vaxigrip.<br>
+     */
+    VAXIGRIP("AHI123",
+             "1.2.40.0.34.5.186",
+             "Vaxigrip",
+             "Vaxigrip",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Vaxigrip junior.<br>
+     */
+    VAXIGRIP_JUNIOR("AHI122",
+                    "1.2.40.0.34.5.186",
+                    "Vaxigrip junior",
+                    "Vaxigrip junior",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Vepacel.<br>
+     */
+    VEPACEL("AHI126",
+            "1.2.40.0.34.5.186",
+            "Vepacel",
+            "Vepacel",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE");
+
+    /**
+     * EN: Code for Acel - P Lederle.<br>
+     */
+    public static final String ACEL_P_LEDERLE_CODE = "AHI001";
+
+    /**
+     * EN: Code for Act-HIB+DPT.<br>
+     */
+    public static final String ACT_HIB_DPT_CODE = "AHI002";
+
+    /**
+     * EN: Code for Addigrip.<br>
+     */
+    public static final String ADDIGRIP_CODE = "AHI003";
+
+    /**
+     * EN: Code for Arepanrix.<br>
+     */
+    public static final String AREPANRIX_CODE = "AHI004";
+
+    /**
+     * EN: Code for Arilvax.<br>
+     */
+    public static final String ARILVAX_CODE = "AHI005";
+
+    /**
+     * EN: Code for Avaxim.<br>
+     */
+    public static final String AVAXIM_CODE = "AHI130";
+
+    /**
+     * EN: Code for Batrevac.<br>
+     */
+    public static final String BATREVAC_CODE = "AHI006";
+
+    /**
+     * EN: Code for BCG Vaccine 'Mérieux'.<br>
+     */
+    public static final String BCG_VACCINE_M_RIEUX_CODE = "AHI007";
+
+    /**
+     * EN: Code for Begrivac.<br>
+     */
+    public static final String BEGRIVAC_CODE = "AHI008";
+
+    /**
+     * EN: Code for Celvapan.<br>
+     */
+    public static final String CELVAPAN_CODE = "AHI009";
+
+    /**
+     * EN: Code for Cholera - Impfstoff 'Berna'.<br>
+     */
+    public static final String CHOLERA_IMPFSTOFF_BERNA_CODE = "AHI010";
+
+    /**
+     * EN: Code for Cholera - Vakzine 'Sero'.<br>
+     */
+    public static final String CHOLERA_VAKZINE_SERO_CODE = "AHI011";
+
+    /**
+     * EN: Code for Daronrix.<br>
+     */
+    public static final String DARONRIX_CODE = "AHI012";
+
+    /**
+     * EN: Code for Diftetall.<br>
+     */
+    public static final String DIFTETALL_CODE = "AHI013";
+
+    /**
+     * EN: Code for Diphtherie Adsorbat Impfstoff 'Behring'.<br>
+     */
+    public static final String DIPHTHERIE_ADSORBAT_IMPFSTOFF_BEHRING_CODE = "AHI014";
+
+    /**
+     * EN: Code for Ditanrix.<br>
+     */
+    public static final String DITANRIX_CODE = "AHI015";
+
+    /**
+     * EN: Code for DiTePer Anatoxal Berna.<br>
+     */
+    public static final String DITEPER_ANATOXAL_BERNA_CODE = "AHI018";
+
+    /**
+     * EN: Code for DiTe Anatoxal Berna.<br>
+     */
+    public static final String DITE_ANATOXAL_BERNA_CODE = "AHI016";
+
+    /**
+     * EN: Code for DiTe Anatoxal(dT) Berna.<br>
+     */
+    public static final String DITE_ANATOXAL_DT_BERNA_CODE = "AHI017";
+
+    /**
+     * EN: Code for DPT Adsorbat 'Mérieux'.<br>
+     */
+    public static final String DPT_ADSORBAT_M_RIEUX_CODE = "AHI020";
+
+    /**
+     * EN: Code for DTaP Vakzine SSI.<br>
+     */
+    public static final String DTAP_VAKZINE_SSI_CODE = "AHI021";
+
+    /**
+     * EN: Code for DT Adsorbat 'Mérieux'.<br>
+     */
+    public static final String DT_ADSORBAT_M_RIEUX_CODE = "AHI019";
+
+    /**
+     * EN: Code for D.T.Vax.<br>
+     */
+    public static final String D_T_VAX_CODE = "AHI022";
+
+    /**
+     * EN: Code for Epaxal.<br>
+     */
+    public static final String EPAXAL_CODE = "AHI023";
+
+    /**
+     * EN: Code for Ervevax.<br>
+     */
+    public static final String ERVEVAX_CODE = "AHI024";
+
+    /**
+     * EN: Code for Fluad.<br>
+     */
+    public static final String FLUAD_CODE = "AHI131";
+
+    /**
+     * EN: Code for Fluarix.<br>
+     */
+    public static final String FLUARIX_CODE = "AHI025";
+
+    /**
+     * EN: Code for Fluenz.<br>
+     */
+    public static final String FLUENZ_CODE = "AHI026";
+
+    /**
+     * EN: Code for Fluvaccinol Subunit.<br>
+     */
+    public static final String FLUVACCINOL_SUBUNIT_CODE = "AHI127";
+
+    /**
+     * EN: Code for Fluvirin.<br>
+     */
+    public static final String FLUVIRIN_CODE = "AHI027";
+
+    /**
+     * EN: Code for Focetria.<br>
+     */
+    public static final String FOCETRIA_CODE = "AHI028";
+
+    /**
+     * EN: Code for Gen-HB-vax 10 ug.<br>
+     */
+    public static final String GEN_HB_VAX_10_UG_CODE = "AHI029";
+
+    /**
+     * EN: Code for Havrix 360 E.I.U./ml.<br>
+     */
+    public static final String HAVRIX_360_E_I_U_ML_CODE = "AHI030";
+
+    /**
+     * EN: Code for Hepacare.<br>
+     */
+    public static final String HEPACARE_CODE = "AHI031";
+
+    /**
+     * EN: Code for Hepatyrix.<br>
+     */
+    public static final String HEPATYRIX_CODE = "AHI032";
+
+    /**
+     * EN: Code for Hevac B 'Pasteur'.<br>
+     */
+    public static final String HEVAC_B_PASTEUR_CODE = "AHI033";
+
+    /**
+     * EN: Code for Hexavac.<br>
+     */
+    public static final String HEXAVAC_CODE = "AHI034";
+
+    /**
+     * EN: Code for Hiberix.<br>
+     */
+    public static final String HIBERIX_CODE = "AHI036";
+
+    /**
+     * EN: Code for HIB-Titer.<br>
+     */
+    public static final String HIB_TITER_CODE = "AHI035";
+
+    /**
+     * EN: Code for Humenza.<br>
+     */
+    public static final String HUMENZA_CODE = "AHI037";
+
+    /**
+     * EN: Code for IDflu.<br>
+     */
+    public static final String IDFLU_CODE = "AHI038";
+
+    /**
+     * EN: Code for Immovax Polio.<br>
+     */
+    public static final String IMMOVAX_POLIO_CODE = "AHI040";
+
+    /**
+     * EN: Code for Immugrip.<br>
+     */
+    public static final String IMMUGRIP_CODE = "AHI039";
+
+    /**
+     * EN: Code for Infanrix.<br>
+     */
+    public static final String INFANRIX_CODE = "AHI041";
+
+    /**
+     * EN: Code for Infanrix + HepB.<br>
+     */
+    public static final String INFANRIX_HEPB_CODE = "AHI044";
+
+    /**
+     * EN: Code for Infanrix + HiB.<br>
+     */
+    public static final String INFANRIX_HIB_CODE = "AHI045";
+
+    /**
+     * EN: Code for Infanrix Penta.<br>
+     */
+    public static final String INFANRIX_PENTA_CODE = "AHI042";
+
+    /**
+     * EN: Code for Infanrix Tetra.<br>
+     */
+    public static final String INFANRIX_TETRA_CODE = "AHI043";
+
+    /**
+     * EN: Code for Inflexal V.<br>
+     */
+    public static final String INFLEXAL_V_CODE = "AHI046";
+
+    /**
+     * EN: Code for Influvac.<br>
+     */
+    public static final String INFLUVAC_CODE = "AHI135";
+
+    /**
+     * EN: Code for Intanza.<br>
+     */
+    public static final String INTANZA_CODE = "AHI047";
+
+    /**
+     * EN: Code for Invivac.<br>
+     */
+    public static final String INVIVAC_CODE = "AHI048";
+
+    /**
+     * EN: Code for IPV Mérieux.<br>
+     */
+    public static final String IPV_M_RIEUX_CODE = "AHI049";
+
+    /**
+     * EN: Code for Japan B Encephalitis Vaccine.<br>
+     */
+    public static final String JAPAN_B_ENCEPHALITIS_VACCINE_CODE = "AHI051";
+
+    /**
+     * EN: Code for JE - Vax.<br>
+     */
+    public static final String JE_VAX_CODE = "AHI050";
+
+    /**
+     * EN: Code for Laevactin.<br>
+     */
+    public static final String LAEVACTIN_CODE = "AHI052";
+
+    /**
+     * EN: Code for Masern Vaccine 'Mérieux'.<br>
+     */
+    public static final String MASERN_VACCINE_M_RIEUX_CODE = "AHI053";
+
+    /**
+     * EN: Code for Menactra.<br>
+     */
+    public static final String MENACTRA_CODE = "AHI059";
+
+    /**
+     * EN: Code for Mencevax ACWY.<br>
+     */
+    public static final String MENCEVAX_ACWY_CODE = "AHI057";
+
+    /**
+     * EN: Code for Meningokokken-Impfstoff A+C Mérieux.<br>
+     */
+    public static final String MENINGOKOKKEN_IMPFSTOFF_A_C_M_RIEUX_CODE = "AHI060";
+
+    /**
+     * EN: Code for Meningovax A+C.<br>
+     */
+    public static final String MENINGOVAX_A_C_CODE = "AHI058";
+
+    /**
+     * EN: Code for Meninvact C.<br>
+     */
+    public static final String MENINVACT_C_CODE = "AHI061";
+
+    /**
+     * EN: Code for Menjugate.<br>
+     */
+    public static final String MENJUGATE_CODE = "AHI134";
+
+    /**
+     * EN: Code for Menomune ACWY.<br>
+     */
+    public static final String MENOMUNE_ACWY_CODE = "AHI054";
+
+    /**
+     * EN: Code for MMR Triplovax.<br>
+     */
+    public static final String MMR_TRIPLOVAX_CODE = "AHI056";
+
+    /**
+     * EN: Code for Mumps Vaccine 'Merieux'.<br>
+     */
+    public static final String MUMPS_VACCINE_MERIEUX_CODE = "AHI055";
+
+    /**
+     * EN: Code for Mutagrip.<br>
+     */
+    public static final String MUTAGRIP_CODE = "AHI062";
+
+    /**
+     * EN: Code for Optaflu.<br>
+     */
+    public static final String OPTAFLU_CODE = "AHI063";
+
+    /**
+     * EN: Code for Orochol.<br>
+     */
+    public static final String OROCHOL_CODE = "AHI064";
+
+    /**
+     * EN: Code for PAC-Mérieux.<br>
+     */
+    public static final String PAC_M_RIEUX_CODE = "AHI065";
+
+    /**
+     * EN: Code for Pandemrix.<br>
+     */
+    public static final String PANDEMRIX_CODE = "AHI066";
+
+    /**
+     * EN: Code for Pariorix.<br>
+     */
+    public static final String PARIORIX_CODE = "AHI067";
+
+    /**
+     * EN: Code for Pediacel.<br>
+     */
+    public static final String PEDIACEL_CODE = "AHI068";
+
+    /**
+     * EN: Code for Pentavac.<br>
+     */
+    public static final String PENTAVAC_CODE = "AHI070";
+
+    /**
+     * EN: Code for Pent-Act-HiB.<br>
+     */
+    public static final String PENT_ACT_HIB_CODE = "AHI069";
+
+    /**
+     * EN: Code for Pertoral.<br>
+     */
+    public static final String PERTORAL_CODE = "AHI071";
+
+    /**
+     * EN: Code for Pneumo 23 'Merieux'.<br>
+     */
+    public static final String PNEUMO_23_MERIEUX_CODE = "AHI075";
+
+    /**
+     * EN: Code for PNU-Imune.<br>
+     */
+    public static final String PNU_IMUNE_CODE = "AHI076";
+
+    /**
+     * EN: Code for Pocken Vaccine.<br>
+     */
+    public static final String POCKEN_VACCINE_CODE = "AHI072";
+
+    /**
+     * EN: Code for Poliomyelitis Vaccine 'Berna'.<br>
+     */
+    public static final String POLIOMYELITIS_VACCINE_BERNA_CODE = "AHI074";
+
+    /**
+     * EN: Code for Polio Sabin (oral) "SB" - Tropfen und Zuckersuspension.<br>
+     */
+    public static final String POLIO_SABIN_ORAL_SB_TROPFEN_UND_ZUCKERSUSPENSION_CODE = "AHI073";
+
+    /**
+     * EN: Code for Preflucel.<br>
+     */
+    public static final String PREFLUCEL_CODE = "AHI124";
+
+    /**
+     * EN: Code for Prepandrix.<br>
+     */
+    public static final String PREPANDRIX_CODE = "AHI132";
+
+    /**
+     * EN: Code for Prevenar (7-valent).<br>
+     */
+    public static final String PREVENAR_7_VALENT_CODE = "AHI080";
+
+    /**
+     * EN: Code for Primavax.<br>
+     */
+    public static final String PRIMAVAX_CODE = "AHI081";
+
+    /**
+     * EN: Code for Procomvax.<br>
+     */
+    public static final String PROCOMVAX_CODE = "AHI082";
+
+    /**
+     * EN: Code for ProHIBiT.<br>
+     */
+    public static final String PROHIBIT_CODE = "AHI084";
+
+    /**
+     * EN: Code for Provarivax.<br>
+     */
+    public static final String PROVARIVAX_CODE = "AHI083";
+
+    /**
+     * EN: Code for Präpandemischer Impfstoff (H5N1) GSK.<br>
+     */
+    public static final String PR_PANDEMISCHER_IMPFSTOFF_H5N1_GSK_CODE = "AHI077";
+
+    /**
+     * EN: Code for Präpandemischer Impfstoff (H5N1) Novartis.<br>
+     */
+    public static final String PR_PANDEMISCHER_IMPFSTOFF_H5N1_NOVARTIS_CODE = "AHI078";
+
+    /**
+     * EN: Code for Prévigrip.<br>
+     */
+    public static final String PR_VIGRIP_CODE = "AHI079";
+
+    /**
+     * EN: Code for Pumarix.<br>
+     */
+    public static final String PUMARIX_CODE = "AHI085";
+
+    /**
+     * EN: Code for Quatrovirelon.<br>
+     */
+    public static final String QUATROVIRELON_CODE = "AHI086";
+
+    /**
+     * EN: Code for Quintanrix.<br>
+     */
+    public static final String QUINTANRIX_CODE = "AHI087";
+
+    /**
+     * EN: Code for Quintovirelon.<br>
+     */
+    public static final String QUINTOVIRELON_CODE = "AHI088";
+
+    /**
+     * EN: Code for Rabies Imovax.<br>
+     */
+    public static final String RABIES_IMOVAX_CODE = "AHI089";
+
+    /**
+     * EN: Code for Rimevax.<br>
+     */
+    public static final String RIMEVAX_CODE = "AHI091";
+
+    /**
+     * EN: Code for Rimparix.<br>
+     */
+    public static final String RIMPARIX_CODE = "AHI090";
+
+    /**
+     * EN: Code for RotaShield.<br>
+     */
+    public static final String ROTASHIELD_CODE = "AHI094";
+
+    /**
+     * EN: Code for Rouvax.<br>
+     */
+    public static final String ROUVAX_CODE = "AHI092";
+
+    /**
+     * EN: Code for Rubeaten 'Berna'.<br>
+     */
+    public static final String RUBEATEN_BERNA_CODE = "AHI096";
+
+    /**
+     * EN: Code for Rudivax.<br>
+     */
+    public static final String RUDIVAX_CODE = "AHI093";
+
+    /**
+     * EN: Code for Röteln-Impfstoff HDC Mérieux.<br>
+     */
+    public static final String R_TELN_IMPFSTOFF_HDC_M_RIEUX_CODE = "AHI095";
+
+    /**
+     * EN: Code for Sandovac.<br>
+     */
+    public static final String SANDOVAC_CODE = "AHI125";
+
+    /**
+     * EN: Code for Silgard.<br>
+     */
+    public static final String SILGARD_CODE = "AHI128";
+
+    /**
+     * EN: Code for Spirolept.<br>
+     */
+    public static final String SPIROLEPT_CODE = "AHI097";
+
+    /**
+     * EN: Code for Tanrix.<br>
+     */
+    public static final String TANRIX_CODE = "AHI098";
+
+    /**
+     * EN: Code for Td-Rix.<br>
+     */
+    public static final String TD_RIX_CODE = "AHI102";
+
+    /**
+     * EN: Code for Tetagrip.<br>
+     */
+    public static final String TETAGRIP_CODE = "AHI103";
+
+    /**
+     * EN: Code for Tetanol.<br>
+     */
+    public static final String TETANOL_CODE = "AHI100";
+
+    /**
+     * EN: Code for Tetanus-Adsorbat 'Merieux'.<br>
+     */
+    public static final String TETANUS_ADSORBAT_MERIEUX_CODE = "AHI101";
+
+    /**
+     * EN: Code for Tetracoq.<br>
+     */
+    public static final String TETRACOQ_CODE = "AHI104";
+
+    /**
+     * EN: Code for Tetravac.<br>
+     */
+    public static final String TETRAVAC_CODE = "AHI133";
+
+    /**
+     * EN: Code for Te-Anatoxal 'Berna'.<br>
+     */
+    public static final String TE_ANATOXAL_BERNA_CODE = "AHI099";
+
+    /**
+     * EN: Code for Ticovac.<br>
+     */
+    public static final String TICOVAC_CODE = "AHI108";
+
+    /**
+     * EN: Code for Ticovac junior.<br>
+     */
+    public static final String TICOVAC_JUNIOR_CODE = "AHI107";
+
+    /**
+     * EN: Code for Tollwut Vaccine HDC.<br>
+     */
+    public static final String TOLLWUT_VACCINE_HDC_CODE = "AHI111";
+
+    /**
+     * EN: Code for Tollwut Vakzine 'Pasteur Merieux'.<br>
+     */
+    public static final String TOLLWUT_VAKZINE_PASTEUR_MERIEUX_CODE = "AHI109";
+
+    /**
+     * EN: Code for Triacelluvax.<br>
+     */
+    public static final String TRIACELLUVAX_CODE = "AHI105";
+
+    /**
+     * EN: Code for Triaxis Polio.<br>
+     */
+    public static final String TRIAXIS_POLIO_CODE = "AHI106";
+
+    /**
+     * EN: Code for Tritanrix DTPw.<br>
+     */
+    public static final String TRITANRIX_DTPW_CODE = "AHI110";
+
+    /**
+     * EN: Code for Tritanrix HepB.<br>
+     */
+    public static final String TRITANRIX_HEPB_CODE = "AHI112";
+
+    /**
+     * EN: Code for Tyavax.<br>
+     */
+    public static final String TYAVAX_CODE = "AHI113";
+
+    /**
+     * EN: Code for Typherix.<br>
+     */
+    public static final String TYPHERIX_CODE = "AHI114";
+
+    /**
+     * EN: Code for Typhoral.<br>
+     */
+    public static final String TYPHORAL_CODE = "AHI115";
+
+    /**
+     * EN: Code for Vaccine Boostrixtetra.<br>
+     */
+    public static final String VACCINE_BOOSTRIXTETRA_CODE = "AHI120";
+
+    /**
+     * EN: Code for Vaccine Rabique Pasteur.<br>
+     */
+    public static final String VACCINE_RABIQUE_PASTEUR_CODE = "AHI118";
+
+    /**
+     * EN: Code for Vaccine Tétamique Pasteur.<br>
+     */
+    public static final String VACCINE_T_TAMIQUE_PASTEUR_CODE = "AHI119";
+
+    /**
+     * EN: Code for Vaccin GenHevac B Pasteur.<br>
+     */
+    public static final String VACCIN_GENHEVAC_B_PASTEUR_CODE = "AHI117";
+
+    /**
+     * EN: Code for Vaccin Rabique inactivé Mérieux HDCV.<br>
+     */
+    public static final String VACCIN_RABIQUE_INACTIV_M_RIEUX_HDCV_CODE = "AHI116";
+
+    /**
+     * EN: Code for Varicella Impfstoff SB.<br>
+     */
+    public static final String VARICELLA_IMPFSTOFF_SB_CODE = "AHI121";
+
+    /**
+     * EN: Code for Vaxigrip.<br>
+     */
+    public static final String VAXIGRIP_CODE = "AHI123";
+
+    /**
+     * EN: Code for Vaxigrip junior.<br>
+     */
+    public static final String VAXIGRIP_JUNIOR_CODE = "AHI122";
+
+    /**
+     * EN: Code for Vepacel.<br>
+     */
+    public static final String VEPACEL_CODE = "AHI126";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.10";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-historischeimpfstoffe";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.186";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfHistorischeimpfstoffe getEnum(@Nullable final String code) {
+        for (final EimpfHistorischeimpfstoffe x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfHistorischeimpfstoffe.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfHistorischeimpfstoffe x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfHistorischeimpfstoffe(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImmunizationtarget.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImmunizationtarget.java
@@ -1,0 +1,1158 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-immunizationtarget values
+ * <p>
+ * EN: Vaccines against a specific disease or pathogen. Substances in this value set represent the individual vaccines (e.g. measles vaccines). Among the combinations are those vaccines that protect against several diseases (e.g. Measles-Mumps-Rubella).<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.4<br>
+ * Effective date: 2025-10-19 14:35<br>
+ * Version: 1.14.0+20251016<br>
+ * Status: FINAL
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfImmunizationtarget implements ValueSetEnumInterface {
+
+    /**
+     * EN: Allgemein empfohlene Impfungen.<br>
+     */
+    ALLGEMEIN_EMPFOHLENE_IMPFUNGEN_L1("_Empfohlene",
+                                      "1.2.40.0.34.5.183",
+                                      "Allgemein empfohlene Impfungen",
+                                      "Allgemein empfohlene Impfungen",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: Chikungunya Impfstoff.<br>
+     */
+    CHIKUNGUNYA_IMPFSTOFF_L2("1345042009",
+                             "2.16.840.1.113883.6.96",
+                             "Chikungunya Impfstoff",
+                             "Chikungunya Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Cholera Impfstoff.<br>
+     */
+    CHOLERA_IMPFSTOFF_L2("836383009",
+                         "2.16.840.1.113883.6.96",
+                         "Cholera Impfstoff",
+                         "Cholera Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: COVID-19 Impfstoff.<br>
+     */
+    COVID_19_IMPFSTOFF_L2("840534001",
+                          "2.16.840.1.113883.6.96",
+                          "COVID-19 Impfstoff",
+                          "COVID-19 Impfstoff",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Dengue-Fieber Impfstoff.<br>
+     */
+    DENGUE_FIEBER_IMPFSTOFF_L2("840563003",
+                               "2.16.840.1.113883.6.96",
+                               "Dengue-Fieber Impfstoff",
+                               "Dengue-Fieber Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Diphtheria-Tetanus-Pertussis-Hepatitis B Impfstoffkombination.<br>
+     */
+    DIPHTHERIA_TETANUS_PERTUSSIS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1("871917002",
+                                                                     "2.16.840.1.113883.6.96",
+                                                                     "Diphtheria-Tetanus-Pertussis-Hepatitis B Impfstoffkombination",
+                                                                     "Diphtheria-Tetanus-Pertussis-Hepatitis B Impfstoffkombination",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Haemophilus-influenzae B-Pertussis-Poliomyelitis-Tetanus-Hepatitis B Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_HAEMOPHILUS_INFLUENZAE_B_PERTUSSIS_POLIOMYELITIS_TETANUS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1("871896006",
+                                                                                                            "2.16.840.1.113883.6.96",
+                                                                                                            "Diphtherie-Haemophilus-influenzae B-Pertussis-Poliomyelitis-Tetanus-Hepatitis B Impfstoffkombination",
+                                                                                                            "Diphtherie-Haemophilus-influenzae B-Pertussis-Poliomyelitis-Tetanus-Hepatitis B Impfstoffkombination",
+                                                                                                            "TOTRANSLATE",
+                                                                                                            "TOTRANSLATE",
+                                                                                                            "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie Impfstoff.<br>
+     */
+    DIPHTHERIE_IMPFSTOFF_L2("836381006",
+                            "2.16.840.1.113883.6.96",
+                            "Diphtherie Impfstoff",
+                            "Diphtherie Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Pertussis-Hepatitis B-Polio Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_PERTUSSIS_HEPATITIS_B_POLIO_IMPFSTOFFKOMBINATION_L1("871889009",
+                                                                   "2.16.840.1.113883.6.96",
+                                                                   "Diphtherie-Pertussis-Hepatitis B-Polio Impfstoffkombination",
+                                                                   "Diphtherie-Pertussis-Hepatitis B-Polio Impfstoffkombination",
+                                                                   "TOTRANSLATE",
+                                                                   "TOTRANSLATE",
+                                                                   "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Pertussis-Poliomyelitis-Tetanus Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_PERTUSSIS_POLIOMYELITIS_TETANUS_IMPFSTOFFKOMBINATION_L1("836508001",
+                                                                       "2.16.840.1.113883.6.96",
+                                                                       "Diphtherie-Pertussis-Poliomyelitis-Tetanus Impfstoffkombination",
+                                                                       "Diphtherie-Pertussis-Poliomyelitis-Tetanus Impfstoffkombination",
+                                                                       "TOTRANSLATE",
+                                                                       "TOTRANSLATE",
+                                                                       "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Pertussis-Tetanus-Haemophilus-influenzae B Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_PERTUSSIS_TETANUS_HAEMOPHILUS_INFLUENZAE_B_IMPFSTOFFKOMBINATION_L1("836507006",
+                                                                                  "2.16.840.1.113883.6.96",
+                                                                                  "Diphtherie-Pertussis-Tetanus-Haemophilus-influenzae B Impfstoffkombination",
+                                                                                  "Diphtherie-Pertussis-Tetanus-Haemophilus-influenzae B Impfstoffkombination",
+                                                                                  "TOTRANSLATE",
+                                                                                  "TOTRANSLATE",
+                                                                                  "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Pertussis-Tetanus Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_PERTUSSIS_TETANUS_IMPFSTOFFKOMBINATION_L1("836503005",
+                                                         "2.16.840.1.113883.6.96",
+                                                         "Diphtherie-Pertussis-Tetanus Impfstoffkombination",
+                                                         "Diphtherie-Pertussis-Tetanus Impfstoffkombination",
+                                                         "TOTRANSLATE",
+                                                         "TOTRANSLATE",
+                                                         "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Pertussis-Tetanus-Poliomyelitis-Haemophilus-influenzae B Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_PERTUSSIS_TETANUS_POLIOMYELITIS_HAEMOPHILUS_INFLUENZAE_B_IMPFSTOFFKOMBINATION_L1("838279002",
+                                                                                                "2.16.840.1.113883.6.96",
+                                                                                                "Diphtherie-Pertussis-Tetanus-Poliomyelitis-Haemophilus-influenzae B Impfstoffkombination",
+                                                                                                "Diphtherie-Pertussis-Tetanus-Poliomyelitis-Haemophilus-influenzae B Impfstoffkombination",
+                                                                                                "TOTRANSLATE",
+                                                                                                "TOTRANSLATE",
+                                                                                                "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Pertussis-Tetanus-Poliomyelitis-Hepatitis B Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_PERTUSSIS_TETANUS_POLIOMYELITIS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1("871892008",
+                                                                                   "2.16.840.1.113883.6.96",
+                                                                                   "Diphtherie-Pertussis-Tetanus-Poliomyelitis-Hepatitis B Impfstoffkombination",
+                                                                                   "Diphtherie-Pertussis-Tetanus-Poliomyelitis-Hepatitis B Impfstoffkombination",
+                                                                                   "TOTRANSLATE",
+                                                                                   "TOTRANSLATE",
+                                                                                   "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Pertussis-Tetanus-Polio-Masern Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_PERTUSSIS_TETANUS_POLIO_MASERN_IMPFSTOFFKOMBINATION_L1("871928003",
+                                                                      "2.16.840.1.113883.6.96",
+                                                                      "Diphtherie-Pertussis-Tetanus-Polio-Masern Impfstoffkombination",
+                                                                      "Diphtherie-Pertussis-Tetanus-Polio-Masern Impfstoffkombination",
+                                                                      "TOTRANSLATE",
+                                                                      "TOTRANSLATE",
+                                                                      "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Poliomyelitis-Tetanus Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_POLIOMYELITIS_TETANUS_IMPFSTOFFKOMBINATION_L1("836505003",
+                                                             "2.16.840.1.113883.6.96",
+                                                             "Diphtherie-Poliomyelitis-Tetanus Impfstoffkombination",
+                                                             "Diphtherie-Poliomyelitis-Tetanus Impfstoffkombination",
+                                                             "TOTRANSLATE",
+                                                             "TOTRANSLATE",
+                                                             "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Tetanus-Hepatitis B Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_TETANUS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1("871929006",
+                                                           "2.16.840.1.113883.6.96",
+                                                           "Diphtherie-Tetanus-Hepatitis B Impfstoffkombination",
+                                                           "Diphtherie-Tetanus-Hepatitis B Impfstoffkombination",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie-Tetanus Impfstoffkombination.<br>
+     */
+    DIPHTHERIE_TETANUS_IMPFSTOFFKOMBINATION_L1("836502000",
+                                               "2.16.840.1.113883.6.96",
+                                               "Diphtherie-Tetanus Impfstoffkombination",
+                                               "Diphtherie-Tetanus Impfstoffkombination",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE"),
+    /**
+     * EN: Ebola Impfstoff.<br>
+     */
+    EBOLA_IMPFSTOFF_L2("836421005",
+                       "2.16.840.1.113883.6.96",
+                       "Ebola Impfstoff",
+                       "Ebola Impfstoff",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Frühsommer-Meningoenzephalitis Impfstoff.<br>
+     */
+    FR_HSOMMER_MENINGOENZEPHALITIS_IMPFSTOFF_L2("836403007",
+                                                "2.16.840.1.113883.6.96",
+                                                "Frühsommer-Meningoenzephalitis Impfstoff",
+                                                "Frühsommer-Meningoenzephalitis Impfstoff",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE"),
+    /**
+     * EN: Gelbfieber Impfstoff.<br>
+     */
+    GELBFIEBER_IMPFSTOFF_L2("836385002",
+                            "2.16.840.1.113883.6.96",
+                            "Gelbfieber Impfstoff",
+                            "Gelbfieber Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Haemophilus influenzae Type B-Tetanus Impfstoffkombination.<br>
+     */
+    HAEMOPHILUS_INFLUENZAE_TYPE_B_TETANUS_IMPFSTOFFKOMBINATION_L1("836504004",
+                                                                  "2.16.840.1.113883.6.96",
+                                                                  "Haemophilus influenzae Type B-Tetanus Impfstoffkombination",
+                                                                  "Haemophilus influenzae Type B-Tetanus Impfstoffkombination",
+                                                                  "TOTRANSLATE",
+                                                                  "TOTRANSLATE",
+                                                                  "TOTRANSLATE"),
+    /**
+     * EN: Haemophilus influenzae Typ B Impfstoff.<br>
+     */
+    HAEMOPHILUS_INFLUENZAE_TYP_B_IMPFSTOFF_L2("836380007",
+                                              "2.16.840.1.113883.6.96",
+                                              "Haemophilus influenzae Typ B Impfstoff",
+                                              "Haemophilus influenzae Typ B Impfstoff",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A-Hepatitis B Impfstoffkombination.<br>
+     */
+    HEPATITIS_A_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1("836493003",
+                                                    "2.16.840.1.113883.6.96",
+                                                    "Hepatitis A-Hepatitis B Impfstoffkombination",
+                                                    "Hepatitis A-Hepatitis B Impfstoffkombination",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A Impfstoff.<br>
+     */
+    HEPATITIS_A_IMPFSTOFF_L2("836375003",
+                             "2.16.840.1.113883.6.96",
+                             "Hepatitis A Impfstoff",
+                             "Hepatitis A Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B-Haemophilus-influenzae B Impfstoffkombination.<br>
+     */
+    HEPATITIS_B_HAEMOPHILUS_INFLUENZAE_B_IMPFSTOFFKOMBINATION_L1("865946000",
+                                                                 "2.16.840.1.113883.6.96",
+                                                                 "Hepatitis B-Haemophilus-influenzae B Impfstoffkombination",
+                                                                 "Hepatitis B-Haemophilus-influenzae B Impfstoffkombination",
+                                                                 "TOTRANSLATE",
+                                                                 "TOTRANSLATE",
+                                                                 "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Impfstoff.<br>
+     */
+    HEPATITIS_B_IMPFSTOFF_L2("836374004",
+                             "2.16.840.1.113883.6.96",
+                             "Hepatitis B Impfstoff",
+                             "Hepatitis B Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster Impfstoff.<br>
+     */
+    HERPES_ZOSTER_IMPFSTOFF_L2("871919004",
+                               "2.16.840.1.113883.6.96",
+                               "Herpes Zoster Impfstoff",
+                               "Herpes Zoster Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Humane Papillomaviren Impfstoff.<br>
+     */
+    HUMANE_PAPILLOMAVIREN_IMPFSTOFF_L2("836379009",
+                                       "2.16.840.1.113883.6.96",
+                                       "Humane Papillomaviren Impfstoff",
+                                       "Humane Papillomaviren Impfstoff",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE"),
+    /**
+     * EN: Impfungen.<br>
+     */
+    IMPFUNGEN("_Einzel",
+              "1.2.40.0.34.5.183",
+              "Impfungen",
+              "Impfungen",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Influenza (H1N1) Impfstoff.<br>
+     */
+    INFLUENZA_H1N1_IMPFSTOFF_L2("871772009",
+                                "2.16.840.1.113883.6.96",
+                                "Influenza (H1N1) Impfstoff",
+                                "Influenza (H1N1) Impfstoff",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Influenza (H5N1) Impfstoff.<br>
+     */
+    INFLUENZA_H5N1_IMPFSTOFF_L2("427036009",
+                                "2.16.840.1.113883.6.96",
+                                "Influenza (H5N1) Impfstoff",
+                                "Influenza (H5N1) Impfstoff",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Influenza (H5N8) Impfstoff.<br>
+     */
+    INFLUENZA_H5N8_IMPFSTOFF_L2("30041000234101",
+                                "2.16.840.1.113883.6.96",
+                                "Influenza (H5N8) Impfstoff",
+                                "Influenza (H5N8) Impfstoff",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Influenza Impfstoff.<br>
+     */
+    INFLUENZA_IMPFSTOFF_L2("836377006",
+                           "2.16.840.1.113883.6.96",
+                           "Influenza Impfstoff",
+                           "Influenza Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Japanische Enzephalitis Impfstoff.<br>
+     */
+    JAPANISCHE_ENZEPHALITIS_IMPFSTOFF_L2("836378001",
+                                         "2.16.840.1.113883.6.96",
+                                         "Japanische Enzephalitis Impfstoff",
+                                         "Japanische Enzephalitis Impfstoff",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsimpfungen.<br>
+     */
+    KOMBINATIONSIMPFUNGEN("_Kombinationen",
+                          "1.2.40.0.34.5.183",
+                          "Kombinationsimpfungen",
+                          "Kombinationsimpfungen",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Leptospirose Impfstoff.<br>
+     */
+    LEPTOSPIROSE_IMPFSTOFF_L2("840564009",
+                              "2.16.840.1.113883.6.96",
+                              "Leptospirose Impfstoff",
+                              "Leptospirose Impfstoff",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Masern Impfstoff.<br>
+     */
+    MASERN_IMPFSTOFF_L2("836382004",
+                        "2.16.840.1.113883.6.96",
+                        "Masern Impfstoff",
+                        "Masern Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Masern-Mumps Impfstoffkombination.<br>
+     */
+    MASERN_MUMPS_IMPFSTOFFKOMBINATION_L1("836499004",
+                                         "2.16.840.1.113883.6.96",
+                                         "Masern-Mumps Impfstoffkombination",
+                                         "Masern-Mumps Impfstoffkombination",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Masern-Mumps-Röteln Impfstoffkombination.<br>
+     */
+    MASERN_MUMPS_R_TELN_IMPFSTOFFKOMBINATION_L1("836494009",
+                                                "2.16.840.1.113883.6.96",
+                                                "Masern-Mumps-Röteln Impfstoffkombination",
+                                                "Masern-Mumps-Röteln Impfstoffkombination",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE"),
+    /**
+     * EN: Masern-Mumps-Röteln-Varizellen Impfstoffkombination.<br>
+     */
+    MASERN_MUMPS_R_TELN_VARIZELLEN_IMPFSTOFFKOMBINATION_L1("838280004",
+                                                           "2.16.840.1.113883.6.96",
+                                                           "Masern-Mumps-Röteln-Varizellen Impfstoffkombination",
+                                                           "Masern-Mumps-Röteln-Varizellen Impfstoffkombination",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Impfstoff.<br>
+     */
+    MENINGOKOKKEN_IMPFSTOFF_L2("836401009",
+                               "2.16.840.1.113883.6.96",
+                               "Meningokokken Impfstoff",
+                               "Meningokokken Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp A+C Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_A_C_IMPFSTOFF_L2("871871008",
+                                           "2.16.840.1.113883.6.96",
+                                           "Meningokokken Serotyp A+C Impfstoff",
+                                           "Meningokokken Serotyp A+C Impfstoff",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp A+C+W135+Y Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_A_C_W135_Y_IMPFSTOFF_L2("871873006",
+                                                  "2.16.840.1.113883.6.96",
+                                                  "Meningokokken Serotyp A+C+W135+Y Impfstoff",
+                                                  "Meningokokken Serotyp A+C+W135+Y Impfstoff",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp B Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_B_IMPFSTOFF_L2("1981000221108",
+                                         "2.16.840.1.113883.6.96",
+                                         "Meningokokken Serotyp B Impfstoff",
+                                         "Meningokokken Serotyp B Impfstoff",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp C Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_C_IMPFSTOFF_L2("871866001",
+                                         "2.16.840.1.113883.6.96",
+                                         "Meningokokken Serotyp C Impfstoff",
+                                         "Meningokokken Serotyp C Impfstoff",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Mpox/Pocken Impfstoff.<br>
+     */
+    MPOX_POCKEN_IMPFSTOFF_L2("836389008",
+                             "2.16.840.1.113883.6.96",
+                             "Mpox/Pocken Impfstoff",
+                             "Mpox/Pocken Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Mumps Impfstoff.<br>
+     */
+    MUMPS_IMPFSTOFF_L2("871738001",
+                       "2.16.840.1.113883.6.96",
+                       "Mumps Impfstoff",
+                       "Mumps Impfstoff",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Pertussis Impfstoff.<br>
+     */
+    PERTUSSIS_IMPFSTOFF_L2("601000221108",
+                           "2.16.840.1.113883.6.96",
+                           "Pertussis Impfstoff",
+                           "Pertussis Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Impfstoff.<br>
+     */
+    PNEUMOKOKKEN_IMPFSTOFF_L2("836398006",
+                              "2.16.840.1.113883.6.96",
+                              "Pneumokokken Impfstoff",
+                              "Pneumokokken Impfstoff",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Poliomyelitis Impfstoff.<br>
+     */
+    POLIOMYELITIS_IMPFSTOFF_L2("1031000221108",
+                               "2.16.840.1.113883.6.96",
+                               "Poliomyelitis Impfstoff",
+                               "Poliomyelitis Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Reise-/Indikationsimpfungen.<br>
+     */
+    REISE_INDIKATIONSIMPFUNGEN_L1("_Reise",
+                                  "1.2.40.0.34.5.183",
+                                  "Reise-/Indikationsimpfungen",
+                                  "Reise-/Indikationsimpfungen",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Respiratorisches Synzytial-Virus Impfstoff.<br>
+     */
+    RESPIRATORISCHES_SYNZYTIAL_VIRUS_IMPFSTOFF_L2("108723008",
+                                                  "2.16.840.1.113883.6.96",
+                                                  "Respiratorisches Synzytial-Virus Impfstoff",
+                                                  "Respiratorisches Synzytial-Virus Impfstoff",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Impfstoff.<br>
+     */
+    ROTAVIRUS_IMPFSTOFF_L2("836387005",
+                           "2.16.840.1.113883.6.96",
+                           "Rotavirus Impfstoff",
+                           "Rotavirus Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Röteln Impfstoff.<br>
+     */
+    R_TELN_IMPFSTOFF_L2("836388000",
+                        "2.16.840.1.113883.6.96",
+                        "Röteln Impfstoff",
+                        "Röteln Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Tetanus Impfstoff.<br>
+     */
+    TETANUS_IMPFSTOFF_L2("1101000221104",
+                         "2.16.840.1.113883.6.96",
+                         "Tetanus Impfstoff",
+                         "Tetanus Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Impfstoff.<br>
+     */
+    TOLLWUT_IMPFSTOFF_L2("836393002",
+                         "2.16.840.1.113883.6.96",
+                         "Tollwut Impfstoff",
+                         "Tollwut Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Tuberkulose Impfstoff.<br>
+     */
+    TUBERKULOSE_IMPFSTOFF_L2("836402002",
+                             "2.16.840.1.113883.6.96",
+                             "Tuberkulose Impfstoff",
+                             "Tuberkulose Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Typhus-Hepatitis A Impfstoffkombination.<br>
+     */
+    TYPHUS_HEPATITIS_A_IMPFSTOFFKOMBINATION_L1("836501007",
+                                               "2.16.840.1.113883.6.96",
+                                               "Typhus-Hepatitis A Impfstoffkombination",
+                                               "Typhus-Hepatitis A Impfstoffkombination",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE"),
+    /**
+     * EN: Typhus Impfstoff.<br>
+     */
+    TYPHUS_IMPFSTOFF_L2("836390004",
+                        "2.16.840.1.113883.6.96",
+                        "Typhus Impfstoff",
+                        "Typhus Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Varizellen Impfstoff.<br>
+     */
+    VARIZELLEN_IMPFSTOFF_L2("836495005",
+                            "2.16.840.1.113883.6.96",
+                            "Varizellen Impfstoff",
+                            "Varizellen Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Weitere Impfungen.<br>
+     */
+    WEITERE_IMPFUNGEN_L1("_Weitere",
+                         "1.2.40.0.34.5.183",
+                         "Weitere Impfungen",
+                         "Weitere Impfungen",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE");
+
+    /**
+     * EN: Code for Allgemein empfohlene Impfungen.<br>
+     */
+    public static final String ALLGEMEIN_EMPFOHLENE_IMPFUNGEN_L1_CODE = "_Empfohlene";
+
+    /**
+     * EN: Code for Chikungunya Impfstoff.<br>
+     */
+    public static final String CHIKUNGUNYA_IMPFSTOFF_L2_CODE = "1345042009";
+
+    /**
+     * EN: Code for Cholera Impfstoff.<br>
+     */
+    public static final String CHOLERA_IMPFSTOFF_L2_CODE = "836383009";
+
+    /**
+     * EN: Code for COVID-19 Impfstoff.<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_L2_CODE = "840534001";
+
+    /**
+     * EN: Code for Dengue-Fieber Impfstoff.<br>
+     */
+    public static final String DENGUE_FIEBER_IMPFSTOFF_L2_CODE = "840563003";
+
+    /**
+     * EN: Code for Diphtheria-Tetanus-Pertussis-Hepatitis B Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIA_TETANUS_PERTUSSIS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1_CODE = "871917002";
+
+    /**
+     * EN: Code for Diphtherie-Haemophilus-influenzae B-Pertussis-Poliomyelitis-Tetanus-Hepatitis B Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_HAEMOPHILUS_INFLUENZAE_B_PERTUSSIS_POLIOMYELITIS_TETANUS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1_CODE = "871896006";
+
+    /**
+     * EN: Code for Diphtherie Impfstoff.<br>
+     */
+    public static final String DIPHTHERIE_IMPFSTOFF_L2_CODE = "836381006";
+
+    /**
+     * EN: Code for Diphtherie-Pertussis-Hepatitis B-Polio Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_PERTUSSIS_HEPATITIS_B_POLIO_IMPFSTOFFKOMBINATION_L1_CODE = "871889009";
+
+    /**
+     * EN: Code for Diphtherie-Pertussis-Poliomyelitis-Tetanus Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_PERTUSSIS_POLIOMYELITIS_TETANUS_IMPFSTOFFKOMBINATION_L1_CODE = "836508001";
+
+    /**
+     * EN: Code for Diphtherie-Pertussis-Tetanus-Haemophilus-influenzae B Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_PERTUSSIS_TETANUS_HAEMOPHILUS_INFLUENZAE_B_IMPFSTOFFKOMBINATION_L1_CODE = "836507006";
+
+    /**
+     * EN: Code for Diphtherie-Pertussis-Tetanus Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_PERTUSSIS_TETANUS_IMPFSTOFFKOMBINATION_L1_CODE = "836503005";
+
+    /**
+     * EN: Code for Diphtherie-Pertussis-Tetanus-Poliomyelitis-Haemophilus-influenzae B Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_PERTUSSIS_TETANUS_POLIOMYELITIS_HAEMOPHILUS_INFLUENZAE_B_IMPFSTOFFKOMBINATION_L1_CODE = "838279002";
+
+    /**
+     * EN: Code for Diphtherie-Pertussis-Tetanus-Poliomyelitis-Hepatitis B Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_PERTUSSIS_TETANUS_POLIOMYELITIS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1_CODE = "871892008";
+
+    /**
+     * EN: Code for Diphtherie-Pertussis-Tetanus-Polio-Masern Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_PERTUSSIS_TETANUS_POLIO_MASERN_IMPFSTOFFKOMBINATION_L1_CODE = "871928003";
+
+    /**
+     * EN: Code for Diphtherie-Poliomyelitis-Tetanus Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_POLIOMYELITIS_TETANUS_IMPFSTOFFKOMBINATION_L1_CODE = "836505003";
+
+    /**
+     * EN: Code for Diphtherie-Tetanus-Hepatitis B Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_TETANUS_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1_CODE = "871929006";
+
+    /**
+     * EN: Code for Diphtherie-Tetanus Impfstoffkombination.<br>
+     */
+    public static final String DIPHTHERIE_TETANUS_IMPFSTOFFKOMBINATION_L1_CODE = "836502000";
+
+    /**
+     * EN: Code for Ebola Impfstoff.<br>
+     */
+    public static final String EBOLA_IMPFSTOFF_L2_CODE = "836421005";
+
+    /**
+     * EN: Code for Frühsommer-Meningoenzephalitis Impfstoff.<br>
+     */
+    public static final String FR_HSOMMER_MENINGOENZEPHALITIS_IMPFSTOFF_L2_CODE = "836403007";
+
+    /**
+     * EN: Code for Gelbfieber Impfstoff.<br>
+     */
+    public static final String GELBFIEBER_IMPFSTOFF_L2_CODE = "836385002";
+
+    /**
+     * EN: Code for Haemophilus influenzae Type B-Tetanus Impfstoffkombination.<br>
+     */
+    public static final String HAEMOPHILUS_INFLUENZAE_TYPE_B_TETANUS_IMPFSTOFFKOMBINATION_L1_CODE = "836504004";
+
+    /**
+     * EN: Code for Haemophilus influenzae Typ B Impfstoff.<br>
+     */
+    public static final String HAEMOPHILUS_INFLUENZAE_TYP_B_IMPFSTOFF_L2_CODE = "836380007";
+
+    /**
+     * EN: Code for Hepatitis A-Hepatitis B Impfstoffkombination.<br>
+     */
+    public static final String HEPATITIS_A_HEPATITIS_B_IMPFSTOFFKOMBINATION_L1_CODE = "836493003";
+
+    /**
+     * EN: Code for Hepatitis A Impfstoff.<br>
+     */
+    public static final String HEPATITIS_A_IMPFSTOFF_L2_CODE = "836375003";
+
+    /**
+     * EN: Code for Hepatitis B-Haemophilus-influenzae B Impfstoffkombination.<br>
+     */
+    public static final String HEPATITIS_B_HAEMOPHILUS_INFLUENZAE_B_IMPFSTOFFKOMBINATION_L1_CODE = "865946000";
+
+    /**
+     * EN: Code for Hepatitis B Impfstoff.<br>
+     */
+    public static final String HEPATITIS_B_IMPFSTOFF_L2_CODE = "836374004";
+
+    /**
+     * EN: Code for Herpes Zoster Impfstoff.<br>
+     */
+    public static final String HERPES_ZOSTER_IMPFSTOFF_L2_CODE = "871919004";
+
+    /**
+     * EN: Code for Humane Papillomaviren Impfstoff.<br>
+     */
+    public static final String HUMANE_PAPILLOMAVIREN_IMPFSTOFF_L2_CODE = "836379009";
+
+    /**
+     * EN: Code for Impfungen.<br>
+     */
+    public static final String IMPFUNGEN_CODE = "_Einzel";
+
+    /**
+     * EN: Code for Influenza (H1N1) Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H1N1_IMPFSTOFF_L2_CODE = "871772009";
+
+    /**
+     * EN: Code for Influenza (H5N1) Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H5N1_IMPFSTOFF_L2_CODE = "427036009";
+
+    /**
+     * EN: Code for Influenza (H5N8) Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H5N8_IMPFSTOFF_L2_CODE = "30041000234101";
+
+    /**
+     * EN: Code for Influenza Impfstoff.<br>
+     */
+    public static final String INFLUENZA_IMPFSTOFF_L2_CODE = "836377006";
+
+    /**
+     * EN: Code for Japanische Enzephalitis Impfstoff.<br>
+     */
+    public static final String JAPANISCHE_ENZEPHALITIS_IMPFSTOFF_L2_CODE = "836378001";
+
+    /**
+     * EN: Code for Kombinationsimpfungen.<br>
+     */
+    public static final String KOMBINATIONSIMPFUNGEN_CODE = "_Kombinationen";
+
+    /**
+     * EN: Code for Leptospirose Impfstoff.<br>
+     */
+    public static final String LEPTOSPIROSE_IMPFSTOFF_L2_CODE = "840564009";
+
+    /**
+     * EN: Code for Masern Impfstoff.<br>
+     */
+    public static final String MASERN_IMPFSTOFF_L2_CODE = "836382004";
+
+    /**
+     * EN: Code for Masern-Mumps Impfstoffkombination.<br>
+     */
+    public static final String MASERN_MUMPS_IMPFSTOFFKOMBINATION_L1_CODE = "836499004";
+
+    /**
+     * EN: Code for Masern-Mumps-Röteln Impfstoffkombination.<br>
+     */
+    public static final String MASERN_MUMPS_R_TELN_IMPFSTOFFKOMBINATION_L1_CODE = "836494009";
+
+    /**
+     * EN: Code for Masern-Mumps-Röteln-Varizellen Impfstoffkombination.<br>
+     */
+    public static final String MASERN_MUMPS_R_TELN_VARIZELLEN_IMPFSTOFFKOMBINATION_L1_CODE = "838280004";
+
+    /**
+     * EN: Code for Meningokokken Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_IMPFSTOFF_L2_CODE = "836401009";
+
+    /**
+     * EN: Code for Meningokokken Serotyp A+C Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_A_C_IMPFSTOFF_L2_CODE = "871871008";
+
+    /**
+     * EN: Code for Meningokokken Serotyp A+C+W135+Y Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_A_C_W135_Y_IMPFSTOFF_L2_CODE = "871873006";
+
+    /**
+     * EN: Code for Meningokokken Serotyp B Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_B_IMPFSTOFF_L2_CODE = "1981000221108";
+
+    /**
+     * EN: Code for Meningokokken Serotyp C Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_C_IMPFSTOFF_L2_CODE = "871866001";
+
+    /**
+     * EN: Code for Mpox/Pocken Impfstoff.<br>
+     */
+    public static final String MPOX_POCKEN_IMPFSTOFF_L2_CODE = "836389008";
+
+    /**
+     * EN: Code for Mumps Impfstoff.<br>
+     */
+    public static final String MUMPS_IMPFSTOFF_L2_CODE = "871738001";
+
+    /**
+     * EN: Code for Pertussis Impfstoff.<br>
+     */
+    public static final String PERTUSSIS_IMPFSTOFF_L2_CODE = "601000221108";
+
+    /**
+     * EN: Code for Pneumokokken Impfstoff.<br>
+     */
+    public static final String PNEUMOKOKKEN_IMPFSTOFF_L2_CODE = "836398006";
+
+    /**
+     * EN: Code for Poliomyelitis Impfstoff.<br>
+     */
+    public static final String POLIOMYELITIS_IMPFSTOFF_L2_CODE = "1031000221108";
+
+    /**
+     * EN: Code for Reise-/Indikationsimpfungen.<br>
+     */
+    public static final String REISE_INDIKATIONSIMPFUNGEN_L1_CODE = "_Reise";
+
+    /**
+     * EN: Code for Respiratorisches Synzytial-Virus Impfstoff.<br>
+     */
+    public static final String RESPIRATORISCHES_SYNZYTIAL_VIRUS_IMPFSTOFF_L2_CODE = "108723008";
+
+    /**
+     * EN: Code for Rotavirus Impfstoff.<br>
+     */
+    public static final String ROTAVIRUS_IMPFSTOFF_L2_CODE = "836387005";
+
+    /**
+     * EN: Code for Röteln Impfstoff.<br>
+     */
+    public static final String R_TELN_IMPFSTOFF_L2_CODE = "836388000";
+
+    /**
+     * EN: Code for Tetanus Impfstoff.<br>
+     */
+    public static final String TETANUS_IMPFSTOFF_L2_CODE = "1101000221104";
+
+    /**
+     * EN: Code for Tollwut Impfstoff.<br>
+     */
+    public static final String TOLLWUT_IMPFSTOFF_L2_CODE = "836393002";
+
+    /**
+     * EN: Code for Tuberkulose Impfstoff.<br>
+     */
+    public static final String TUBERKULOSE_IMPFSTOFF_L2_CODE = "836402002";
+
+    /**
+     * EN: Code for Typhus-Hepatitis A Impfstoffkombination.<br>
+     */
+    public static final String TYPHUS_HEPATITIS_A_IMPFSTOFFKOMBINATION_L1_CODE = "836501007";
+
+    /**
+     * EN: Code for Typhus Impfstoff.<br>
+     */
+    public static final String TYPHUS_IMPFSTOFF_L2_CODE = "836390004";
+
+    /**
+     * EN: Code for Varizellen Impfstoff.<br>
+     */
+    public static final String VARIZELLEN_IMPFSTOFF_L2_CODE = "836495005";
+
+    /**
+     * EN: Code for Weitere Impfungen.<br>
+     */
+    public static final String WEITERE_IMPFUNGEN_L1_CODE = "_Weitere";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.4";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-immunizationtarget";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.183";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfImmunizationtarget getEnum(@Nullable final String code) {
+        for (final EimpfImmunizationtarget x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfImmunizationtarget.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfImmunizationtarget x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfImmunizationtarget(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfdosis.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfdosis.java
@@ -1,0 +1,408 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-impfdosis values
+ * <p>
+ * EN: Vaccine doses or partial vaccinations for immunisation, basic immunisation and boosters.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.6<br>
+ * Effective date: 2021-11-09 00:00<br>
+ * Version: 1.4.0+20240910<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfImpfdosis implements ValueSetEnumInterface {
+
+    /**
+     * EN: Auffrischung.<br>
+     */
+    AUFFRISCHUNG("B",
+                 "1.2.40.0.34.5.183",
+                 "Auffrischung",
+                 "Auffrischung",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Auffrischungsserie Teil 1.<br>
+     */
+    AUFFRISCHUNGSSERIE_TEIL_1("B.I",
+                              "1.2.40.0.34.5.183",
+                              "Auffrischungsserie Teil 1",
+                              "Auffrischungsserie Teil 1",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Auffrischungsserie Teil 2.<br>
+     */
+    AUFFRISCHUNGSSERIE_TEIL_2("B.II",
+                              "1.2.40.0.34.5.183",
+                              "Auffrischungsserie Teil 2",
+                              "Auffrischungsserie Teil 2",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Dosis 1.<br>
+     */
+    DOSIS_1("D1",
+            "1.2.40.0.34.5.183",
+            "Dosis 1",
+            "Dosis 1",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 2.<br>
+     */
+    DOSIS_2("D2",
+            "1.2.40.0.34.5.183",
+            "Dosis 2",
+            "Dosis 2",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 3.<br>
+     */
+    DOSIS_3("D3",
+            "1.2.40.0.34.5.183",
+            "Dosis 3",
+            "Dosis 3",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 4.<br>
+     */
+    DOSIS_4("D4",
+            "1.2.40.0.34.5.183",
+            "Dosis 4",
+            "Dosis 4",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 5.<br>
+     */
+    DOSIS_5("D5",
+            "1.2.40.0.34.5.183",
+            "Dosis 5",
+            "Dosis 5",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 6.<br>
+     */
+    DOSIS_6("D6",
+            "1.2.40.0.34.5.183",
+            "Dosis 6",
+            "Dosis 6",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 7.<br>
+     */
+    DOSIS_7("D7",
+            "1.2.40.0.34.5.183",
+            "Dosis 7",
+            "Dosis 7",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 8.<br>
+     */
+    DOSIS_8("D8",
+            "1.2.40.0.34.5.183",
+            "Dosis 8",
+            "Dosis 8",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Dosis 9.<br>
+     */
+    DOSIS_9("D9",
+            "1.2.40.0.34.5.183",
+            "Dosis 9",
+            "Dosis 9",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE");
+
+    /**
+     * EN: Code for Auffrischung.<br>
+     */
+    public static final String AUFFRISCHUNG_CODE = "B";
+
+    /**
+     * EN: Code for Auffrischungsserie Teil 1.<br>
+     */
+    public static final String AUFFRISCHUNGSSERIE_TEIL_1_CODE = "B.I";
+
+    /**
+     * EN: Code for Auffrischungsserie Teil 2.<br>
+     */
+    public static final String AUFFRISCHUNGSSERIE_TEIL_2_CODE = "B.II";
+
+    /**
+     * EN: Code for Dosis 1.<br>
+     */
+    public static final String DOSIS_1_CODE = "D1";
+
+    /**
+     * EN: Code for Dosis 2.<br>
+     */
+    public static final String DOSIS_2_CODE = "D2";
+
+    /**
+     * EN: Code for Dosis 3.<br>
+     */
+    public static final String DOSIS_3_CODE = "D3";
+
+    /**
+     * EN: Code for Dosis 4.<br>
+     */
+    public static final String DOSIS_4_CODE = "D4";
+
+    /**
+     * EN: Code for Dosis 5.<br>
+     */
+    public static final String DOSIS_5_CODE = "D5";
+
+    /**
+     * EN: Code for Dosis 6.<br>
+     */
+    public static final String DOSIS_6_CODE = "D6";
+
+    /**
+     * EN: Code for Dosis 7.<br>
+     */
+    public static final String DOSIS_7_CODE = "D7";
+
+    /**
+     * EN: Code for Dosis 8.<br>
+     */
+    public static final String DOSIS_8_CODE = "D8";
+
+    /**
+     * EN: Code for Dosis 9.<br>
+     */
+    public static final String DOSIS_9_CODE = "D9";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.6";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-impfdosis";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.183";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfImpfdosis getEnum(@Nullable final String code) {
+        for (final EimpfImpfdosis x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfImpfdosis.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfImpfdosis x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfImpfdosis(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfgrund.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfgrund.java
@@ -1,0 +1,258 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-impfgrund values
+ * <p>
+ * EN: Billing-related reasons for vaccinations.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.7<br>
+ * Effective date: 2019-08-01 00:00<br>
+ * Version: 201908(-beta)<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfImpfgrund implements ValueSetEnumInterface {
+
+    /**
+     * EN: Indikationsimpfung für Risikogruppe.<br>
+     */
+    INDIKATIONSIMPFUNG_F_R_RISIKOGRUPPE("IG1",
+                                        "1.2.40.0.34.5.183",
+                                        "Indikationsimpfung für Risikogruppe",
+                                        "Indikationsimpfung für Risikogruppe",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE"),
+    /**
+     * EN: Wiederholungsimpfung aufgrund medizinischer Indikation.<br>
+     */
+    WIEDERHOLUNGSIMPFUNG_AUFGRUND_MEDIZINISCHER_INDIKATION("IG2",
+                                                           "1.2.40.0.34.5.183",
+                                                           "Wiederholungsimpfung aufgrund medizinischer Indikation",
+                                                           "Wiederholungsimpfung aufgrund medizinischer Indikation",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE");
+
+    /**
+     * EN: Code for Indikationsimpfung für Risikogruppe.<br>
+     */
+    public static final String INDIKATIONSIMPFUNG_F_R_RISIKOGRUPPE_CODE = "IG1";
+
+    /**
+     * EN: Code for Wiederholungsimpfung aufgrund medizinischer Indikation.<br>
+     */
+    public static final String WIEDERHOLUNGSIMPFUNG_AUFGRUND_MEDIZINISCHER_INDIKATION_CODE = "IG2";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.7";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-impfgrund";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.183";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfImpfgrund getEnum(@Nullable final String code) {
+        for (final EimpfImpfgrund x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfImpfgrund.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfImpfgrund x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfImpfgrund(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfrollen.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfrollen.java
@@ -1,0 +1,363 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-impfrollen values
+ * <p>
+ * EN: Professional groups from the Health Telematics Regulation that carry out vaccinations.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.11<br>
+ * Effective date: 2025-07-29 07:34<br>
+ * Version: 1.2.0+20250723<br>
+ * Status: FINAL
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfImpfrollen implements ValueSetEnumInterface {
+
+    /**
+     * EN: Approbierte Ärztin/Approbierter Arzt.<br>
+     */
+    APPROBIERTE_RZTIN_APPROBIERTER_ARZT("101",
+                                        "1.2.40.0.34.5.2",
+                                        "Approbierte Ärztin/Approbierter Arzt",
+                                        "Approbierte Ärztin/Approbierter Arzt",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE"),
+    /**
+     * EN: Diplomierte Gesundheits- und Krankenschwester/Diplomierter Gesundheits- und Krankenpfleger.<br>
+     */
+    DIPLOMIERTE_GESUNDHEITS_UND_KRANKENSCHWESTER_DIPLOMIERTER_GESUNDHEITS_UND_KRANKENPFLEGER("212",
+                                                                                             "1.2.40.0.34.5.2",
+                                                                                             "Diplomierte Gesundheits- und Krankenschwester/Diplomierter Gesundheits- und Krankenpfleger",
+                                                                                             "Diplomierte Gesundheits- und Krankenschwester/Diplomierter Gesundheits- und Krankenpfleger",
+                                                                                             "TOTRANSLATE",
+                                                                                             "TOTRANSLATE",
+                                                                                             "TOTRANSLATE"),
+    /**
+     * EN: Diplomierte Kinderkrankenschwester/Diplomierter Kinderkrankenpfleger.<br>
+     */
+    DIPLOMIERTE_KINDERKRANKENSCHWESTER_DIPLOMIERTER_KINDERKRANKENPFLEGER("213",
+                                                                         "1.2.40.0.34.5.2",
+                                                                         "Diplomierte Kinderkrankenschwester/Diplomierter Kinderkrankenpfleger",
+                                                                         "Diplomierte Kinderkrankenschwester/Diplomierter Kinderkrankenpfleger",
+                                                                         "TOTRANSLATE",
+                                                                         "TOTRANSLATE",
+                                                                         "TOTRANSLATE"),
+    /**
+     * EN: Diplomierte psychiatrische Gesundheits- und Krankenschwester/Diplomierter psychiatrischer Gesundheits- und Krankenpfleger.<br>
+     */
+    DIPLOMIERTE_PSYCHIATRISCHE_GESUNDHEITS_UND_KRANKENSCHWESTER_DIPLOMIERTER_PSYCHIATRISCHER_GESUNDHEITS_UND_KRANKENPFLEGER("214",
+                                                                                                                            "1.2.40.0.34.5.2",
+                                                                                                                            "Diplomierte psychiatrische Gesundheits- und Krankenschwester/Diplomierter psychiatrischer Gesundheits- und Krankenpfleger",
+                                                                                                                            "Diplomierte psychiatrische Gesundheits- und Krankenschwester/Diplomierter psychiatrischer Gesundheits- und Krankenpfleger",
+                                                                                                                            "TOTRANSLATE",
+                                                                                                                            "TOTRANSLATE",
+                                                                                                                            "TOTRANSLATE"),
+    /**
+     * EN: Fachärztin/Facharzt, gemäß ÄAO 2006.<br>
+     */
+    FACH_RZTIN_FACHARZT_GEM_SS_AO_2006_L1("158",
+                                          "1.2.40.0.34.5.2",
+                                          "Fachärztin/Facharzt, gemäß ÄAO 2006",
+                                          "Fachärztin/Facharzt, gemäß ÄAO 2006",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Fachärztin/Facharzt, gemäß ÄAO 2015.<br>
+     */
+    FACH_RZTIN_FACHARZT_GEM_SS_AO_2015_L1("159",
+                                          "1.2.40.0.34.5.2",
+                                          "Fachärztin/Facharzt, gemäß ÄAO 2015",
+                                          "Fachärztin/Facharzt, gemäß ÄAO 2015",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Hebamme.<br>
+     */
+    HEBAMME("204",
+            "1.2.40.0.34.5.2",
+            "Hebamme",
+            "Hebamme",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Ärztin/Arzt.<br>
+     */
+    _RZTIN_ARZT("1000",
+                "1.2.40.0.34.5.2",
+                "Ärztin/Arzt",
+                "Ärztin/Arzt",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Ärztin/Arzt für Allgemeinmedizin.<br>
+     */
+    _RZTIN_ARZT_F_R_ALLGEMEINMEDIZIN_L1("100",
+                                        "1.2.40.0.34.5.2",
+                                        "Ärztin/Arzt für Allgemeinmedizin",
+                                        "Ärztin/Arzt für Allgemeinmedizin",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE");
+
+    /**
+     * EN: Code for Approbierte Ärztin/Approbierter Arzt.<br>
+     */
+    public static final String APPROBIERTE_RZTIN_APPROBIERTER_ARZT_CODE = "101";
+
+    /**
+     * EN: Code for Diplomierte Gesundheits- und Krankenschwester/Diplomierter Gesundheits- und Krankenpfleger.<br>
+     */
+    public static final String DIPLOMIERTE_GESUNDHEITS_UND_KRANKENSCHWESTER_DIPLOMIERTER_GESUNDHEITS_UND_KRANKENPFLEGER_CODE = "212";
+
+    /**
+     * EN: Code for Diplomierte Kinderkrankenschwester/Diplomierter Kinderkrankenpfleger.<br>
+     */
+    public static final String DIPLOMIERTE_KINDERKRANKENSCHWESTER_DIPLOMIERTER_KINDERKRANKENPFLEGER_CODE = "213";
+
+    /**
+     * EN: Code for Diplomierte psychiatrische Gesundheits- und Krankenschwester/Diplomierter psychiatrischer Gesundheits- und Krankenpfleger.<br>
+     */
+    public static final String DIPLOMIERTE_PSYCHIATRISCHE_GESUNDHEITS_UND_KRANKENSCHWESTER_DIPLOMIERTER_PSYCHIATRISCHER_GESUNDHEITS_UND_KRANKENPFLEGER_CODE = "214";
+
+    /**
+     * EN: Code for Fachärztin/Facharzt, gemäß ÄAO 2006.<br>
+     */
+    public static final String FACH_RZTIN_FACHARZT_GEM_SS_AO_2006_L1_CODE = "158";
+
+    /**
+     * EN: Code for Fachärztin/Facharzt, gemäß ÄAO 2015.<br>
+     */
+    public static final String FACH_RZTIN_FACHARZT_GEM_SS_AO_2015_L1_CODE = "159";
+
+    /**
+     * EN: Code for Hebamme.<br>
+     */
+    public static final String HEBAMME_CODE = "204";
+
+    /**
+     * EN: Code for Ärztin/Arzt.<br>
+     */
+    public static final String _RZTIN_ARZT_CODE = "1000";
+
+    /**
+     * EN: Code for Ärztin/Arzt für Allgemeinmedizin.<br>
+     */
+    public static final String _RZTIN_ARZT_F_R_ALLGEMEINMEDIZIN_L1_CODE = "100";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.11";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-impfrollen";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.2";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfImpfrollen getEnum(@Nullable final String code) {
+        for (final EimpfImpfrollen x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfImpfrollen.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfImpfrollen x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfImpfrollen(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfschema.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfschema.java
@@ -357,13 +357,13 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Hepatitis AB, Schnellschema.<br>
      */
-    HEPATITIS_AB_SCHNELLSCHEMA("SCHEMA258",
-                               "1.2.40.0.34.5.183",
-                               "Hepatitis AB, Schnellschema",
-                               "Hepatitis AB, Schnellschema",
-                               "TOTRANSLATE",
-                               "TOTRANSLATE",
-                               "TOTRANSLATE"),
+    // HEPATITIS_AB_SCHNELLSCHEMA("SCHEMA258",
+    //                            "1.2.40.0.34.5.183",
+    //                            "Hepatitis AB, Schnellschema",
+    //                            "Hepatitis AB, Schnellschema",
+    //                            "TOTRANSLATE",
+    //                            "TOTRANSLATE",
+    //                            "TOTRANSLATE"),
     /**
      * EN: Hepatitis A Monokomponente Grundschema.<br>
      */
@@ -1637,13 +1637,13 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Tollwut, Schnellschema.<br>
      */
-    TOLLWUT_SCHNELLSCHEMA("SCHEMA250",
-                          "1.2.40.0.34.5.183",
-                          "Tollwut, Schnellschema",
-                          "Tollwut, Schnellschema",
-                          "TOTRANSLATE",
-                          "TOTRANSLATE",
-                          "TOTRANSLATE"),
+    // TOLLWUT_SCHNELLSCHEMA("SCHEMA250",
+    //                       "1.2.40.0.34.5.183",
+    //                       "Tollwut, Schnellschema",
+    //                       "Tollwut, Schnellschema",
+    //                       "TOTRANSLATE",
+    //                       "TOTRANSLATE",
+    //                       "TOTRANSLATE"),
     /**
      * EN: Tollwut Schnellschema (WHO).<br>
      */
@@ -1657,13 +1657,13 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Tollwut, Schnellschema (WHO).<br>
      */
-    TOLLWUT_SCHNELLSCHEMA_WHO("SCHEMA251",
-                              "1.2.40.0.34.5.183",
-                              "Tollwut, Schnellschema (WHO)",
-                              "Tollwut, Schnellschema (WHO)",
-                              "TOTRANSLATE",
-                              "TOTRANSLATE",
-                              "TOTRANSLATE"),
+    // TOLLWUT_SCHNELLSCHEMA_WHO("SCHEMA251",
+    //                           "1.2.40.0.34.5.183",
+    //                           "Tollwut, Schnellschema (WHO)",
+    //                           "Tollwut, Schnellschema (WHO)",
+    //                           "TOTRANSLATE",
+    //                           "TOTRANSLATE",
+    //                           "TOTRANSLATE"),
     /**
      * EN: Tollwut Schnellschema (WHO), intradermal.<br>
      */
@@ -1677,13 +1677,13 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Tollwut, Schnellschema (WHO) intradermal.<br>
      */
-    TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL("SCHEMA252",
-                                          "1.2.40.0.34.5.183",
-                                          "Tollwut, Schnellschema (WHO) intradermal",
-                                          "Tollwut, Schnellschema (WHO) intradermal",
-                                          "TOTRANSLATE",
-                                          "TOTRANSLATE",
-                                          "TOTRANSLATE"),
+    // TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL("SCHEMA252",
+    //                                       "1.2.40.0.34.5.183",
+    //                                       "Tollwut, Schnellschema (WHO) intradermal",
+    //                                       "Tollwut, Schnellschema (WHO) intradermal",
+    //                                       "TOTRANSLATE",
+    //                                       "TOTRANSLATE",
+    //                                       "TOTRANSLATE"),
     /**
      * EN: Typhus.<br>
      */
@@ -1928,7 +1928,7 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Code for Hepatitis AB, Schnellschema.<br>
      */
-    public static final String HEPATITIS_AB_SCHNELLSCHEMA_CODE = "SCHEMA258";
+    // public static final String HEPATITIS_AB_SCHNELLSCHEMA_CODE = "SCHEMA258";
 
     /**
      * EN: Code for Hepatitis A Monokomponente Grundschema.<br>
@@ -2568,7 +2568,7 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Code for Tollwut, Schnellschema.<br>
      */
-    public static final String TOLLWUT_SCHNELLSCHEMA_CODE = "SCHEMA250";
+    // public static final String TOLLWUT_SCHNELLSCHEMA_CODE = "SCHEMA250";
 
     /**
      * EN: Code for Tollwut Schnellschema (WHO).<br>
@@ -2578,7 +2578,7 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Code for Tollwut, Schnellschema (WHO).<br>
      */
-    public static final String TOLLWUT_SCHNELLSCHEMA_WHO_CODE = "SCHEMA251";
+    // public static final String TOLLWUT_SCHNELLSCHEMA_WHO_CODE = "SCHEMA251";
 
     /**
      * EN: Code for Tollwut Schnellschema (WHO), intradermal.<br>
@@ -2588,7 +2588,7 @@ public enum EimpfImpfschema implements ValueSetEnumInterface {
     /**
      * EN: Code for Tollwut, Schnellschema (WHO) intradermal.<br>
      */
-    public static final String TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL_CODE = "SCHEMA252";
+    // public static final String TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL_CODE = "SCHEMA252";
 
     /**
      * EN: Code for Typhus.<br>

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfschema.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfschema.java
@@ -1,0 +1,2823 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-impfschema values
+ * <p>
+ * EN: Rules on vaccine doses for obtaining or refreshing (boosting) basic immunisation.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.5<br>
+ * Effective date: 2025-10-19 15:43<br>
+ * Version: 2.27.0+20251016<br>
+ * Status: FINAL
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfImpfschema implements ValueSetEnumInterface {
+
+    /**
+     * EN: Chikungunya.<br>
+     */
+    CHIKUNGUNYA("SCHEMA256",
+                "1.2.40.0.34.5.183",
+                "Chikungunya",
+                "Chikungunya",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Cholera.<br>
+     */
+    CHOLERA("SCHEMA203",
+            "1.2.40.0.34.5.183",
+            "Cholera",
+            "Cholera",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Cholera Grundschema, Erstimpfung 2-6 Jahre.<br>
+     */
+    CHOLERA_GRUNDSCHEMA_ERSTIMPFUNG_2_6_JAHRE("SCHEMA076",
+                                              "1.2.40.0.34.5.183",
+                                              "Cholera Grundschema, Erstimpfung 2-6 Jahre",
+                                              "Cholera Grundschema, Erstimpfung 2-6 Jahre",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: Cholera Grundschema, Erstimpfung ab 6 Jahren.<br>
+     */
+    CHOLERA_GRUNDSCHEMA_ERSTIMPFUNG_AB_6_JAHREN("SCHEMA078",
+                                                "1.2.40.0.34.5.183",
+                                                "Cholera Grundschema, Erstimpfung ab 6 Jahren",
+                                                "Cholera Grundschema, Erstimpfung ab 6 Jahren",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE"),
+    /**
+     * EN: COVID-19.<br>
+     */
+    COVID_19("SCHEMA204",
+             "1.2.40.0.34.5.183",
+             "COVID-19",
+             "COVID-19",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: COVID-19 Grundschema.<br>
+     */
+    COVID_19_GRUNDSCHEMA("SCHEMA122",
+                         "1.2.40.0.34.5.183",
+                         "COVID-19 Grundschema",
+                         "COVID-19 Grundschema",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: COVID-19 Grundschema, Kleinkind.<br>
+     */
+    COVID_19_GRUNDSCHEMA_KLEINKIND("SCHEMA117",
+                                   "1.2.40.0.34.5.183",
+                                   "COVID-19 Grundschema, Kleinkind",
+                                   "COVID-19 Grundschema, Kleinkind",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE"),
+    /**
+     * EN: COVID-19, Indikation.<br>
+     */
+    COVID_19_INDIKATION("SCHEMA205",
+                        "1.2.40.0.34.5.183",
+                        "COVID-19, Indikation",
+                        "COVID-19, Indikation",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: COVID-19 Indikationsschema.<br>
+     */
+    COVID_19_INDIKATIONSSCHEMA("SCHEMA110",
+                               "1.2.40.0.34.5.183",
+                               "COVID-19 Indikationsschema",
+                               "COVID-19 Indikationsschema",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: COVID-19, Indikation Grundimmunisierung bis 5 Jahre.<br>
+     */
+    COVID_19_INDIKATION_GRUNDIMMUNISIERUNG_BIS_5_JAHRE("SCHEMA260",
+                                                       "1.2.40.0.34.5.183",
+                                                       "COVID-19, Indikation Grundimmunisierung bis 5 Jahre",
+                                                       "COVID-19, Indikation Grundimmunisierung bis 5 Jahre",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE"),
+    /**
+     * EN: Dengue.<br>
+     */
+    DENGUE("SCHEMA206",
+           "1.2.40.0.34.5.183",
+           "Dengue",
+           "Dengue",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Dengue-Fieber Grundschema, 2 Dosen.<br>
+     */
+    DENGUE_FIEBER_GRUNDSCHEMA_2_DOSEN("SCHEMA119",
+                                      "1.2.40.0.34.5.183",
+                                      "Dengue-Fieber Grundschema, 2 Dosen",
+                                      "Dengue-Fieber Grundschema, 2 Dosen",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: Di-Te-Pert.<br>
+     */
+    DI_TE_PERT("SCHEMA207",
+               "1.2.40.0.34.5.183",
+               "Di-Te-Pert",
+               "Di-Te-Pert",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Di-Te-Pert-IPV.<br>
+     */
+    DI_TE_PERT_IPV("SCHEMA208",
+                   "1.2.40.0.34.5.183",
+                   "Di-Te-Pert-IPV",
+                   "Di-Te-Pert-IPV",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Di-Te-Pert-IPV, Indikation.<br>
+     */
+    DI_TE_PERT_IPV_INDIKATION("SCHEMA259",
+                              "1.2.40.0.34.5.183",
+                              "Di-Te-Pert-IPV, Indikation",
+                              "Di-Te-Pert-IPV, Indikation",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: FSME.<br>
+     */
+    FSME("SCHEMA209",
+         "1.2.40.0.34.5.183",
+         "FSME",
+         "FSME",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: FSME, beschleunigtes konventionelles Schema.<br>
+     */
+    FSME_BESCHLEUNIGTES_KONVENTIONELLES_SCHEMA("SCHEMA210",
+                                               "1.2.40.0.34.5.183",
+                                               "FSME, beschleunigtes konventionelles Schema",
+                                               "FSME, beschleunigtes konventionelles Schema",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE"),
+    /**
+     * EN: FSME beschleunigtes konventionelles Schema, Encepur.<br>
+     */
+    FSME_BESCHLEUNIGTES_KONVENTIONELLES_SCHEMA_ENCEPUR("SCHEMA126",
+                                                       "1.2.40.0.34.5.183",
+                                                       "FSME beschleunigtes konventionelles Schema, Encepur",
+                                                       "FSME beschleunigtes konventionelles Schema, Encepur",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE"),
+    /**
+     * EN: FSME Grundschema, Encepur.<br>
+     */
+    FSME_GRUNDSCHEMA_ENCEPUR("SCHEMA006",
+                             "1.2.40.0.34.5.183",
+                             "FSME Grundschema, Encepur",
+                             "FSME Grundschema, Encepur",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: FSME Grundschema, Encepur, Erstimpfung bis 1 Jahr.<br>
+     */
+    FSME_GRUNDSCHEMA_ENCEPUR_ERSTIMPFUNG_BIS_1_JAHR("SCHEMA008",
+                                                    "1.2.40.0.34.5.183",
+                                                    "FSME Grundschema, Encepur, Erstimpfung bis 1 Jahr",
+                                                    "FSME Grundschema, Encepur, Erstimpfung bis 1 Jahr",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: FSME Grundschema, FSME-Immun.<br>
+     */
+    FSME_GRUNDSCHEMA_FSME_IMMUN("SCHEMA005",
+                                "1.2.40.0.34.5.183",
+                                "FSME Grundschema, FSME-Immun",
+                                "FSME Grundschema, FSME-Immun",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: FSME Grundschema, FSME-Immun, Erstimpfung bis 1 Jahr.<br>
+     */
+    FSME_GRUNDSCHEMA_FSME_IMMUN_ERSTIMPFUNG_BIS_1_JAHR("SCHEMA007",
+                                                       "1.2.40.0.34.5.183",
+                                                       "FSME Grundschema, FSME-Immun, Erstimpfung bis 1 Jahr",
+                                                       "FSME Grundschema, FSME-Immun, Erstimpfung bis 1 Jahr",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE"),
+    /**
+     * EN: FSME, Schnellschema.<br>
+     */
+    FSME_SCHNELLSCHEMA("SCHEMA211",
+                       "1.2.40.0.34.5.183",
+                       "FSME, Schnellschema",
+                       "FSME, Schnellschema",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: FSME Schnellschema, Encepur.<br>
+     */
+    FSME_SCHNELLSCHEMA_ENCEPUR("SCHEMA010",
+                               "1.2.40.0.34.5.183",
+                               "FSME Schnellschema, Encepur",
+                               "FSME Schnellschema, Encepur",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: FSME Schnellschema, FSME-Immun.<br>
+     */
+    FSME_SCHNELLSCHEMA_FSME_IMMUN("SCHEMA009",
+                                  "1.2.40.0.34.5.183",
+                                  "FSME Schnellschema, FSME-Immun",
+                                  "FSME Schnellschema, FSME-Immun",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Gelbfieber.<br>
+     */
+    GELBFIEBER("SCHEMA212",
+               "1.2.40.0.34.5.183",
+               "Gelbfieber",
+               "Gelbfieber",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Gelbfieber Grundschema, ab dem vollendeten 9. Lebensmonat.<br>
+     */
+    GELBFIEBER_GRUNDSCHEMA_AB_DEM_VOLLENDETEN_9_LEBENSMONAT("SCHEMA065",
+                                                            "1.2.40.0.34.5.183",
+                                                            "Gelbfieber Grundschema, ab dem vollendeten 9. Lebensmonat",
+                                                            "Gelbfieber Grundschema, ab dem vollendeten 9. Lebensmonat",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE"),
+    /**
+     * EN: Haemophilus influenzae Typ B Indikationsschema.<br>
+     */
+    HAEMOPHILUS_INFLUENZAE_TYP_B_INDIKATIONSSCHEMA("SCHEMA011",
+                                                   "1.2.40.0.34.5.183",
+                                                   "Haemophilus influenzae Typ B Indikationsschema",
+                                                   "Haemophilus influenzae Typ B Indikationsschema",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A.<br>
+     */
+    HEPATITIS_A("SCHEMA213",
+                "1.2.40.0.34.5.183",
+                "Hepatitis A",
+                "Hepatitis A",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis AB.<br>
+     */
+    HEPATITIS_AB("SCHEMA215",
+                 "1.2.40.0.34.5.183",
+                 "Hepatitis AB",
+                 "Hepatitis AB",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis AB Grundschema.<br>
+     */
+    HEPATITIS_AB_GRUNDSCHEMA("SCHEMA013",
+                             "1.2.40.0.34.5.183",
+                             "Hepatitis AB Grundschema",
+                             "Hepatitis AB Grundschema",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis AB Schnellschema.<br>
+     */
+    HEPATITIS_AB_SCHNELLSCHEMA("SCHEMA015",
+                               "1.2.40.0.34.5.183",
+                               "Hepatitis AB Schnellschema",
+                               "Hepatitis AB Schnellschema",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis AB, Schnellschema.<br>
+     */
+    HEPATITIS_AB_SCHNELLSCHEMA("SCHEMA258",
+                               "1.2.40.0.34.5.183",
+                               "Hepatitis AB, Schnellschema",
+                               "Hepatitis AB, Schnellschema",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A Monokomponente Grundschema.<br>
+     */
+    HEPATITIS_A_MONOKOMPONENTE_GRUNDSCHEMA("SCHEMA014",
+                                           "1.2.40.0.34.5.183",
+                                           "Hepatitis A Monokomponente Grundschema",
+                                           "Hepatitis A Monokomponente Grundschema",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A Monokomponente Indikationsschema.<br>
+     */
+    HEPATITIS_A_MONOKOMPONENTE_INDIKATIONSSCHEMA("SCHEMA012",
+                                                 "1.2.40.0.34.5.183",
+                                                 "Hepatitis A Monokomponente Indikationsschema",
+                                                 "Hepatitis A Monokomponente Indikationsschema",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A &amp; Typhus Grundschema.<br>
+     */
+    HEPATITIS_A_TYPHUS_GRUNDSCHEMA("SCHEMA016",
+                                   "1.2.40.0.34.5.183",
+                                   "Hepatitis A & Typhus Grundschema",
+                                   "Hepatitis A & Typhus Grundschema",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B.<br>
+     */
+    HEPATITIS_B("SCHEMA216",
+                "1.2.40.0.34.5.183",
+                "Hepatitis B",
+                "Hepatitis B",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B, Indikation.<br>
+     */
+    HEPATITIS_B_INDIKATION("SCHEMA217",
+                           "1.2.40.0.34.5.183",
+                           "Hepatitis B, Indikation",
+                           "Hepatitis B, Indikation",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B, Indikation Prophylaxe Neugeborener.<br>
+     */
+    HEPATITIS_B_INDIKATION_PROPHYLAXE_NEUGEBORENER("SCHEMA218",
+                                                   "1.2.40.0.34.5.183",
+                                                   "Hepatitis B, Indikation Prophylaxe Neugeborener",
+                                                   "Hepatitis B, Indikation Prophylaxe Neugeborener",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Monokomponente Grundschema.<br>
+     */
+    HEPATITIS_B_MONOKOMPONENTE_GRUNDSCHEMA("SCHEMA017",
+                                           "1.2.40.0.34.5.183",
+                                           "Hepatitis B Monokomponente Grundschema",
+                                           "Hepatitis B Monokomponente Grundschema",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Monokomponente Indikationsschema.<br>
+     */
+    HEPATITIS_B_MONOKOMPONENTE_INDIKATIONSSCHEMA("SCHEMA085",
+                                                 "1.2.40.0.34.5.183",
+                                                 "Hepatitis B Monokomponente Indikationsschema",
+                                                 "Hepatitis B Monokomponente Indikationsschema",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Monokomponente Schnellschema durch Indikation.<br>
+     */
+    HEPATITIS_B_MONOKOMPONENTE_SCHNELLSCHEMA_DURCH_INDIKATION("SCHEMA102",
+                                                              "1.2.40.0.34.5.183",
+                                                              "Hepatitis B Monokomponente Schnellschema durch Indikation",
+                                                              "Hepatitis B Monokomponente Schnellschema durch Indikation",
+                                                              "TOTRANSLATE",
+                                                              "TOTRANSLATE",
+                                                              "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Non-/Low-Responder Indikationsschema.<br>
+     */
+    HEPATITIS_B_NON_LOW_RESPONDER_INDIKATIONSSCHEMA("SCHEMA019",
+                                                    "1.2.40.0.34.5.183",
+                                                    "Hepatitis B Non-/Low-Responder Indikationsschema",
+                                                    "Hepatitis B Non-/Low-Responder Indikationsschema",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Prophylaxe Neugeborener Indikationsschema.<br>
+     */
+    HEPATITIS_B_PROPHYLAXE_NEUGEBORENER_INDIKATIONSSCHEMA("SCHEMA103",
+                                                          "1.2.40.0.34.5.183",
+                                                          "Hepatitis B Prophylaxe Neugeborener Indikationsschema",
+                                                          "Hepatitis B Prophylaxe Neugeborener Indikationsschema",
+                                                          "TOTRANSLATE",
+                                                          "TOTRANSLATE",
+                                                          "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B, Schnellschema.<br>
+     */
+    HEPATITIS_B_SCHNELLSCHEMA("SCHEMA219",
+                              "1.2.40.0.34.5.183",
+                              "Hepatitis B, Schnellschema",
+                              "Hepatitis B, Schnellschema",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster.<br>
+     */
+    HERPES_ZOSTER("SCHEMA220",
+                  "1.2.40.0.34.5.183",
+                  "Herpes Zoster",
+                  "Herpes Zoster",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster Grundschema, ab 50 Jahren.<br>
+     */
+    HERPES_ZOSTER_GRUNDSCHEMA_AB_50_JAHREN("SCHEMA064",
+                                           "1.2.40.0.34.5.183",
+                                           "Herpes Zoster Grundschema, ab 50 Jahren",
+                                           "Herpes Zoster Grundschema, ab 50 Jahren",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster Grundschema, nach Zostavax.<br>
+     */
+    HERPES_ZOSTER_GRUNDSCHEMA_NACH_ZOSTAVAX("SCHEMA091",
+                                            "1.2.40.0.34.5.183",
+                                            "Herpes Zoster Grundschema, nach Zostavax",
+                                            "Herpes Zoster Grundschema, nach Zostavax",
+                                            "TOTRANSLATE",
+                                            "TOTRANSLATE",
+                                            "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster, Indikation.<br>
+     */
+    HERPES_ZOSTER_INDIKATION("SCHEMA221",
+                             "1.2.40.0.34.5.183",
+                             "Herpes Zoster, Indikation",
+                             "Herpes Zoster, Indikation",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster Indikationsschema, ab 18 Jahren.<br>
+     */
+    HERPES_ZOSTER_INDIKATIONSSCHEMA_AB_18_JAHREN("SCHEMA092",
+                                                 "1.2.40.0.34.5.183",
+                                                 "Herpes Zoster Indikationsschema, ab 18 Jahren",
+                                                 "Herpes Zoster Indikationsschema, ab 18 Jahren",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: HiB, Indikation.<br>
+     */
+    HIB_INDIKATION("SCHEMA222",
+                   "1.2.40.0.34.5.183",
+                   "HiB, Indikation",
+                   "HiB, Indikation",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: HPV.<br>
+     */
+    HPV("SCHEMA223",
+        "1.2.40.0.34.5.183",
+        "HPV",
+        "HPV",
+        "TOTRANSLATE",
+        "TOTRANSLATE",
+        "TOTRANSLATE"),
+    /**
+     * EN: HPV Grundschema.<br>
+     */
+    HPV_GRUNDSCHEMA("SCHEMA020",
+                    "1.2.40.0.34.5.183",
+                    "HPV Grundschema",
+                    "HPV Grundschema",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: HPV Grundschema, ab 21 Jahren.<br>
+     */
+    HPV_GRUNDSCHEMA_AB_21_JAHREN("SCHEMA021",
+                                 "1.2.40.0.34.5.183",
+                                 "HPV Grundschema, ab 21 Jahren",
+                                 "HPV Grundschema, ab 21 Jahren",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: HPV, Indikation.<br>
+     */
+    HPV_INDIKATION("SCHEMA224",
+                   "1.2.40.0.34.5.183",
+                   "HPV, Indikation",
+                   "HPV, Indikation",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: HPV Indikationsschema.<br>
+     */
+    HPV_INDIKATIONSSCHEMA("SCHEMA022",
+                          "1.2.40.0.34.5.183",
+                          "HPV Indikationsschema",
+                          "HPV Indikationsschema",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Influenza.<br>
+     */
+    INFLUENZA("SCHEMA225",
+              "1.2.40.0.34.5.183",
+              "Influenza",
+              "Influenza",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Influenza Grundschema, Einmalimpfung.<br>
+     */
+    INFLUENZA_GRUNDSCHEMA_EINMALIMPFUNG("SCHEMA024",
+                                        "1.2.40.0.34.5.183",
+                                        "Influenza Grundschema, Einmalimpfung",
+                                        "Influenza Grundschema, Einmalimpfung",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE"),
+    /**
+     * EN: Influenza Grundschema, Erstimpfung Kinder.<br>
+     */
+    INFLUENZA_GRUNDSCHEMA_ERSTIMPFUNG_KINDER("SCHEMA023",
+                                             "1.2.40.0.34.5.183",
+                                             "Influenza Grundschema, Erstimpfung Kinder",
+                                             "Influenza Grundschema, Erstimpfung Kinder",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE"),
+    /**
+     * EN: Influenza, Indikation.<br>
+     */
+    INFLUENZA_INDIKATION("SCHEMA226",
+                         "1.2.40.0.34.5.183",
+                         "Influenza, Indikation",
+                         "Influenza, Indikation",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Influenza Indikationsschema.<br>
+     */
+    INFLUENZA_INDIKATIONSSCHEMA("SCHEMA104",
+                                "1.2.40.0.34.5.183",
+                                "Influenza Indikationsschema",
+                                "Influenza Indikationsschema",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Japanische Enzephalitis.<br>
+     */
+    JAPANISCHE_ENZEPHALITIS("SCHEMA227",
+                            "1.2.40.0.34.5.183",
+                            "Japanische Enzephalitis",
+                            "Japanische Enzephalitis",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Japanische Enzephalitis Grundschema, ab 2 Monaten.<br>
+     */
+    JAPANISCHE_ENZEPHALITIS_GRUNDSCHEMA_AB_2_MONATEN("SCHEMA066",
+                                                     "1.2.40.0.34.5.183",
+                                                     "Japanische Enzephalitis Grundschema, ab 2 Monaten",
+                                                     "Japanische Enzephalitis Grundschema, ab 2 Monaten",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE"),
+    /**
+     * EN: Japanische Enzephalitis, Schnellschema.<br>
+     */
+    JAPANISCHE_ENZEPHALITIS_SCHNELLSCHEMA("SCHEMA228",
+                                          "1.2.40.0.34.5.183",
+                                          "Japanische Enzephalitis, Schnellschema",
+                                          "Japanische Enzephalitis, Schnellschema",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Japanische Enzephalitis Schnellschema, ab 18 Jahren.<br>
+     */
+    JAPANISCHE_ENZEPHALITIS_SCHNELLSCHEMA_AB_18_JAHREN("SCHEMA067",
+                                                       "1.2.40.0.34.5.183",
+                                                       "Japanische Enzephalitis Schnellschema, ab 18 Jahren",
+                                                       "Japanische Enzephalitis Schnellschema, ab 18 Jahren",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE("SCHEMA082",
+                             "1.2.40.0.34.5.183",
+                             "Kombinationsschema Di-Te",
+                             "Kombinationsschema Di-Te",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te-IPV.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE_IPV("SCHEMA105",
+                                 "1.2.40.0.34.5.183",
+                                 "Kombinationsschema Di-Te-IPV",
+                                 "Kombinationsschema Di-Te-IPV",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te-Pert.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE_PERT("SCHEMA081",
+                                  "1.2.40.0.34.5.183",
+                                  "Kombinationsschema Di-Te-Pert",
+                                  "Kombinationsschema Di-Te-Pert",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung ab 1 Jahr.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE_PERT_HIB_IPV_HEPB_ERSTIMPFUNG_AB_1_JAHR("SCHEMA002",
+                                                                     "1.2.40.0.34.5.183",
+                                                                     "Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung ab 1 Jahr",
+                                                                     "Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung ab 1 Jahr",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung bis 1 Jahr.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE_PERT_HIB_IPV_HEPB_ERSTIMPFUNG_BIS_1_JAHR("SCHEMA001",
+                                                                      "1.2.40.0.34.5.183",
+                                                                      "Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung bis 1 Jahr",
+                                                                      "Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung bis 1 Jahr",
+                                                                      "TOTRANSLATE",
+                                                                      "TOTRANSLATE",
+                                                                      "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Indikation.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE_PERT_HIB_IPV_HEPB_INDIKATION("SCHEMA004",
+                                                          "1.2.40.0.34.5.183",
+                                                          "Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Indikation",
+                                                          "Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Indikation",
+                                                          "TOTRANSLATE",
+                                                          "TOTRANSLATE",
+                                                          "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te-Pert-IPV.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE_PERT_IPV("SCHEMA080",
+                                      "1.2.40.0.34.5.183",
+                                      "Kombinationsschema Di-Te-Pert-IPV",
+                                      "Kombinationsschema Di-Te-Pert-IPV",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema Di-Te-Pert-IPV-HepB, Erstimpfung ab 6 Jahren.<br>
+     */
+    KOMBINATIONSSCHEMA_DI_TE_PERT_IPV_HEPB_ERSTIMPFUNG_AB_6_JAHREN("SCHEMA003",
+                                                                   "1.2.40.0.34.5.183",
+                                                                   "Kombinationsschema Di-Te-Pert-IPV-HepB, Erstimpfung ab 6 Jahren",
+                                                                   "Kombinationsschema Di-Te-Pert-IPV-HepB, Erstimpfung ab 6 Jahren",
+                                                                   "TOTRANSLATE",
+                                                                   "TOTRANSLATE",
+                                                                   "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMRV.<br>
+     */
+    KOMBINATIONSSCHEMA_MMRV_AB_12_MONATEN_MMRV_MMRV("SCHEMA101",
+                                                    "1.2.40.0.34.5.183",
+                                                    "Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMRV",
+                                                    "Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMRV",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMR - V.<br>
+     */
+    KOMBINATIONSSCHEMA_MMRV_AB_12_MONATEN_MMRV_MMR_V("SCHEMA114",
+                                                     "1.2.40.0.34.5.183",
+                                                     "Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMR - V",
+                                                     "Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMR - V",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema MMRV, ab 12 Monaten, MMR - MMRV - V.<br>
+     */
+    KOMBINATIONSSCHEMA_MMRV_AB_12_MONATEN_MMR_MMRV_V("SCHEMA062",
+                                                     "1.2.40.0.34.5.183",
+                                                     "Kombinationsschema MMRV, ab 12 Monaten, MMR - MMRV - V",
+                                                     "Kombinationsschema MMRV, ab 12 Monaten, MMR - MMRV - V",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMRV.<br>
+     */
+    KOMBINATIONSSCHEMA_MMRV_AB_9_MONATEN_MMRV_MMRV("SCHEMA100",
+                                                   "1.2.40.0.34.5.183",
+                                                   "Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMRV",
+                                                   "Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMRV",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMR - V.<br>
+     */
+    KOMBINATIONSSCHEMA_MMRV_AB_9_MONATEN_MMRV_MMR_V("SCHEMA113",
+                                                    "1.2.40.0.34.5.183",
+                                                    "Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMR - V",
+                                                    "Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMR - V",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: Kombinationsschema MMRV, ab 9 Monaten, MMR - MMRV - V.<br>
+     */
+    KOMBINATIONSSCHEMA_MMRV_AB_9_MONATEN_MMR_MMRV_V("SCHEMA061",
+                                                    "1.2.40.0.34.5.183",
+                                                    "Kombinationsschema MMRV, ab 9 Monaten, MMR - MMRV - V",
+                                                    "Kombinationsschema MMRV, ab 9 Monaten, MMR - MMRV - V",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY.<br>
+     */
+    MENINGOKOKKEN_ACWY("SCHEMA229",
+                       "1.2.40.0.34.5.183",
+                       "Meningokokken ACWY",
+                       "Meningokokken ACWY",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY, ab 1 Jahr.<br>
+     */
+    MENINGOKOKKEN_ACWY_AB_1_JAHR("SCHEMA125",
+                                 "1.2.40.0.34.5.183",
+                                 "Meningokokken ACWY, ab 1 Jahr",
+                                 "Meningokokken ACWY, ab 1 Jahr",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY Grundschema, ab 10 Jahren.<br>
+     */
+    MENINGOKOKKEN_ACWY_GRUNDSCHEMA_AB_10_JAHREN("SCHEMA039",
+                                                "1.2.40.0.34.5.183",
+                                                "Meningokokken ACWY Grundschema, ab 10 Jahren",
+                                                "Meningokokken ACWY Grundschema, ab 10 Jahren",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY, Indikation.<br>
+     */
+    MENINGOKOKKEN_ACWY_INDIKATION("SCHEMA230",
+                                  "1.2.40.0.34.5.183",
+                                  "Meningokokken ACWY, Indikation",
+                                  "Meningokokken ACWY, Indikation",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY Indikationsschema, ab 1 Jahr.<br>
+     */
+    MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_AB_1_JAHR("SCHEMA040",
+                                                   "1.2.40.0.34.5.183",
+                                                   "Meningokokken ACWY Indikationsschema, ab 1 Jahr",
+                                                   "Meningokokken ACWY Indikationsschema, ab 1 Jahr",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY Indikationsschema, Erstimpfung bis 1 Jahr.<br>
+     */
+    MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_ERSTIMPFUNG_BIS_1_JAHR("SCHEMA041",
+                                                                "1.2.40.0.34.5.183",
+                                                                "Meningokokken ACWY Indikationsschema, Erstimpfung bis 1 Jahr",
+                                                                "Meningokokken ACWY Indikationsschema, Erstimpfung bis 1 Jahr",
+                                                                "TOTRANSLATE",
+                                                                "TOTRANSLATE",
+                                                                "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY Indikationsschema, Menveo ab 2 Jahre.<br>
+     */
+    MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_MENVEO_AB_2_JAHRE("SCHEMA109",
+                                                           "1.2.40.0.34.5.183",
+                                                           "Meningokokken ACWY Indikationsschema, Menveo ab 2 Jahre",
+                                                           "Meningokokken ACWY Indikationsschema, Menveo ab 2 Jahre",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY Indikationsschema, Nimenrix ab 1 Jahr.<br>
+     */
+    MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_NIMENRIX_AB_1_JAHR("SCHEMA108",
+                                                            "1.2.40.0.34.5.183",
+                                                            "Meningokokken ACWY Indikationsschema, Nimenrix ab 1 Jahr",
+                                                            "Meningokokken ACWY Indikationsschema, Nimenrix ab 1 Jahr",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY Indikationsschema, Nimenrix ab 6 Monate.<br>
+     */
+    MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_NIMENRIX_AB_6_MONATE("SCHEMA107",
+                                                              "1.2.40.0.34.5.183",
+                                                              "Meningokokken ACWY Indikationsschema, Nimenrix ab 6 Monate",
+                                                              "Meningokokken ACWY Indikationsschema, Nimenrix ab 6 Monate",
+                                                              "TOTRANSLATE",
+                                                              "TOTRANSLATE",
+                                                              "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken ACWY Indikationsschema, Nimenrix bis 6 Monate.<br>
+     */
+    MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_NIMENRIX_BIS_6_MONATE("SCHEMA106",
+                                                               "1.2.40.0.34.5.183",
+                                                               "Meningokokken ACWY Indikationsschema, Nimenrix bis 6 Monate",
+                                                               "Meningokokken ACWY Indikationsschema, Nimenrix bis 6 Monate",
+                                                               "TOTRANSLATE",
+                                                               "TOTRANSLATE",
+                                                               "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B.<br>
+     */
+    MENINGOKOKKEN_B("SCHEMA231",
+                    "1.2.40.0.34.5.183",
+                    "Meningokokken B",
+                    "Meningokokken B",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Grundschema, Erstimpfung 10-25 Jahre, Trumenba.<br>
+     */
+    MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_10_25_JAHRE_TRUMENBA("SCHEMA079",
+                                                                 "1.2.40.0.34.5.183",
+                                                                 "Meningokokken B Grundschema, Erstimpfung 10-25 Jahre, Trumenba",
+                                                                 "Meningokokken B Grundschema, Erstimpfung 10-25 Jahre, Trumenba",
+                                                                 "TOTRANSLATE",
+                                                                 "TOTRANSLATE",
+                                                                 "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Grundschema, Erstimpfung 12-23 Monate.<br>
+     */
+    MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_12_23_MONATE("SCHEMA031",
+                                                         "1.2.40.0.34.5.183",
+                                                         "Meningokokken B Grundschema, Erstimpfung 12-23 Monate",
+                                                         "Meningokokken B Grundschema, Erstimpfung 12-23 Monate",
+                                                         "TOTRANSLATE",
+                                                         "TOTRANSLATE",
+                                                         "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Grundschema, Erstimpfung 2-25 Jahre, Bexsero.<br>
+     */
+    MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_2_25_JAHRE_BEXSERO("SCHEMA032",
+                                                               "1.2.40.0.34.5.183",
+                                                               "Meningokokken B Grundschema, Erstimpfung 2-25 Jahre, Bexsero",
+                                                               "Meningokokken B Grundschema, Erstimpfung 2-25 Jahre, Bexsero",
+                                                               "TOTRANSLATE",
+                                                               "TOTRANSLATE",
+                                                               "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Grundschema, Erstimpfung 2-5 Monate.<br>
+     */
+    MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_2_5_MONATE("SCHEMA029",
+                                                       "1.2.40.0.34.5.183",
+                                                       "Meningokokken B Grundschema, Erstimpfung 2-5 Monate",
+                                                       "Meningokokken B Grundschema, Erstimpfung 2-5 Monate",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Grundschema, Erstimpfung 2-5 Monate, 4 Dosen.<br>
+     */
+    MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_2_5_MONATE_4_DOSEN("SCHEMA028",
+                                                               "1.2.40.0.34.5.183",
+                                                               "Meningokokken B Grundschema, Erstimpfung 2-5 Monate, 4 Dosen",
+                                                               "Meningokokken B Grundschema, Erstimpfung 2-5 Monate, 4 Dosen",
+                                                               "TOTRANSLATE",
+                                                               "TOTRANSLATE",
+                                                               "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Grundschema, Erstimpfung 6-11 Monate.<br>
+     */
+    MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_6_11_MONATE("SCHEMA030",
+                                                        "1.2.40.0.34.5.183",
+                                                        "Meningokokken B Grundschema, Erstimpfung 6-11 Monate",
+                                                        "Meningokokken B Grundschema, Erstimpfung 6-11 Monate",
+                                                        "TOTRANSLATE",
+                                                        "TOTRANSLATE",
+                                                        "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B, Indikation.<br>
+     */
+    MENINGOKOKKEN_B_INDIKATION("SCHEMA232",
+                               "1.2.40.0.34.5.183",
+                               "Meningokokken B, Indikation",
+                               "Meningokokken B, Indikation",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Indikationsschema, ab 25 Jahren, Bexsero.<br>
+     */
+    MENINGOKOKKEN_B_INDIKATIONSSCHEMA_AB_25_JAHREN_BEXSERO("SCHEMA033",
+                                                           "1.2.40.0.34.5.183",
+                                                           "Meningokokken B Indikationsschema, ab 25 Jahren, Bexsero",
+                                                           "Meningokokken B Indikationsschema, ab 25 Jahren, Bexsero",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken B Indikationsschema, ab 25 Jahren, Trumenba.<br>
+     */
+    MENINGOKOKKEN_B_INDIKATIONSSCHEMA_AB_25_JAHREN_TRUMENBA("SCHEMA034",
+                                                            "1.2.40.0.34.5.183",
+                                                            "Meningokokken B Indikationsschema, ab 25 Jahren, Trumenba",
+                                                            "Meningokokken B Indikationsschema, ab 25 Jahren, Trumenba",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken C.<br>
+     */
+    MENINGOKOKKEN_C("SCHEMA233",
+                    "1.2.40.0.34.5.183",
+                    "Meningokokken C",
+                    "Meningokokken C",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken C Grundschema, ab 1 Jahr.<br>
+     */
+    MENINGOKOKKEN_C_GRUNDSCHEMA_AB_1_JAHR("SCHEMA038",
+                                          "1.2.40.0.34.5.183",
+                                          "Meningokokken C Grundschema, ab 1 Jahr",
+                                          "Meningokokken C Grundschema, ab 1 Jahr",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken C Indikationsschema, 2-12 Monate, Menjugate.<br>
+     */
+    MENINGOKOKKEN_C_INDIKATIONSSCHEMA_2_12_MONATE_MENJUGATE("SCHEMA036",
+                                                            "1.2.40.0.34.5.183",
+                                                            "Meningokokken C Indikationsschema, 2-12 Monate, Menjugate",
+                                                            "Meningokokken C Indikationsschema, 2-12 Monate, Menjugate",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken C Indikationsschema, 2-4 Monate, Neisvac C.<br>
+     */
+    MENINGOKOKKEN_C_INDIKATIONSSCHEMA_2_4_MONATE_NEISVAC_C("SCHEMA035",
+                                                           "1.2.40.0.34.5.183",
+                                                           "Meningokokken C Indikationsschema, 2-4 Monate, Neisvac C",
+                                                           "Meningokokken C Indikationsschema, 2-4 Monate, Neisvac C",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken C Indikationsschema, 4-12 Monate, Neisvac C.<br>
+     */
+    MENINGOKOKKEN_C_INDIKATIONSSCHEMA_4_12_MONATE_NEISVAC_C("SCHEMA037",
+                                                            "1.2.40.0.34.5.183",
+                                                            "Meningokokken C Indikationsschema, 4-12 Monate, Neisvac C",
+                                                            "Meningokokken C Indikationsschema, 4-12 Monate, Neisvac C",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE",
+                                                            "TOTRANSLATE"),
+    /**
+     * EN: MMR.<br>
+     */
+    MMR("SCHEMA234",
+        "1.2.40.0.34.5.183",
+        "MMR",
+        "MMR",
+        "TOTRANSLATE",
+        "TOTRANSLATE",
+        "TOTRANSLATE"),
+    /**
+     * EN: MMRV.<br>
+     */
+    MMRV("SCHEMA237",
+         "1.2.40.0.34.5.183",
+         "MMRV",
+         "MMRV",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: MMR Grundschema, ab 1 Jahr.<br>
+     */
+    MMR_GRUNDSCHEMA_AB_1_JAHR("SCHEMA093",
+                              "1.2.40.0.34.5.183",
+                              "MMR Grundschema, ab 1 Jahr",
+                              "MMR Grundschema, ab 1 Jahr",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: MMR Grundschema ab 9 Monaten.<br>
+     */
+    MMR_GRUNDSCHEMA_AB_9_MONATEN("SCHEMA025",
+                                 "1.2.40.0.34.5.183",
+                                 "MMR Grundschema ab 9 Monaten",
+                                 "MMR Grundschema ab 9 Monaten",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: MMR, Indikation.<br>
+     */
+    MMR_INDIKATION("SCHEMA236",
+                   "1.2.40.0.34.5.183",
+                   "MMR, Indikation",
+                   "MMR, Indikation",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: MMR Indikationsschema, Erstimpfung 6-8 Monate.<br>
+     */
+    MMR_INDIKATIONSSCHEMA_ERSTIMPFUNG_6_8_MONATE("SCHEMA027",
+                                                 "1.2.40.0.34.5.183",
+                                                 "MMR Indikationsschema, Erstimpfung 6-8 Monate",
+                                                 "MMR Indikationsschema, Erstimpfung 6-8 Monate",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: MMR - MMRV - V.<br>
+     */
+    MMR_MMRV_V("SCHEMA235",
+               "1.2.40.0.34.5.183",
+               "MMR - MMRV - V",
+               "MMR - MMRV - V",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Mpox.<br>
+     */
+    MPOX("SCHEMA238",
+         "1.2.40.0.34.5.183",
+         "Mpox",
+         "Mpox",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: Mpox/Pocken Indikationsschema.<br>
+     */
+    MPOX_POCKEN_INDIKATIONSSCHEMA("SCHEMA111",
+                                  "1.2.40.0.34.5.183",
+                                  "Mpox/Pocken Indikationsschema",
+                                  "Mpox/Pocken Indikationsschema",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Mpox/Pocken Indikationsschema, einmalige Impfung.<br>
+     */
+    MPOX_POCKEN_INDIKATIONSSCHEMA_EINMALIGE_IMPFUNG("SCHEMA115",
+                                                    "1.2.40.0.34.5.183",
+                                                    "Mpox/Pocken Indikationsschema, einmalige Impfung",
+                                                    "Mpox/Pocken Indikationsschema, einmalige Impfung",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken.<br>
+     */
+    PNEUMOKOKKEN("SCHEMA239",
+                 "1.2.40.0.34.5.183",
+                 "Pneumokokken",
+                 "Pneumokokken",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken, Frühgeborene (3+1).<br>
+     */
+    PNEUMOKOKKEN_FR_HGEBORENE_3_1("SCHEMA241",
+                                  "1.2.40.0.34.5.183",
+                                  "Pneumokokken, Frühgeborene (3+1)",
+                                  "Pneumokokken, Frühgeborene (3+1)",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken, Frühgeborene mit Indikation (3+1).<br>
+     */
+    PNEUMOKOKKEN_FR_HGEBORENE_MIT_INDIKATION_3_1("SCHEMA243",
+                                                 "1.2.40.0.34.5.183",
+                                                 "Pneumokokken, Frühgeborene mit Indikation (3+1)",
+                                                 "Pneumokokken, Frühgeborene mit Indikation (3+1)",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Grundschema, ab 60 Jahre.<br>
+     */
+    PNEUMOKOKKEN_GRUNDSCHEMA_AB_60_JAHRE("SCHEMA098",
+                                         "1.2.40.0.34.5.183",
+                                         "Pneumokokken Grundschema, ab 60 Jahre",
+                                         "Pneumokokken Grundschema, ab 60 Jahre",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Grundschema, Erstimpfung 1-2 Jahre.<br>
+     */
+    PNEUMOKOKKEN_GRUNDSCHEMA_ERSTIMPFUNG_1_2_JAHRE("SCHEMA043",
+                                                   "1.2.40.0.34.5.183",
+                                                   "Pneumokokken Grundschema, Erstimpfung 1-2 Jahre",
+                                                   "Pneumokokken Grundschema, Erstimpfung 1-2 Jahre",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Grundschema, Erstimpfung 2-5 Jahre.<br>
+     */
+    PNEUMOKOKKEN_GRUNDSCHEMA_ERSTIMPFUNG_2_5_JAHRE("SCHEMA097",
+                                                   "1.2.40.0.34.5.183",
+                                                   "Pneumokokken Grundschema, Erstimpfung 2-5 Jahre",
+                                                   "Pneumokokken Grundschema, Erstimpfung 2-5 Jahre",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Grundschema, Erstimpfung bis 1 Jahr.<br>
+     */
+    PNEUMOKOKKEN_GRUNDSCHEMA_ERSTIMPFUNG_BIS_1_JAHR("SCHEMA042",
+                                                    "1.2.40.0.34.5.183",
+                                                    "Pneumokokken Grundschema, Erstimpfung bis 1 Jahr",
+                                                    "Pneumokokken Grundschema, Erstimpfung bis 1 Jahr",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken, Indikation.<br>
+     */
+    PNEUMOKOKKEN_INDIKATION("SCHEMA242",
+                            "1.2.40.0.34.5.183",
+                            "Pneumokokken, Indikation",
+                            "Pneumokokken, Indikation",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Indikationsschema (erhöhtes Risiko), ab 50 Jahren.<br>
+     */
+    PNEUMOKOKKEN_INDIKATIONSSCHEMA_ERH_HTES_RISIKO_AB_50_JAHREN("SCHEMA116",
+                                                                "1.2.40.0.34.5.183",
+                                                                "Pneumokokken Indikationsschema (erhöhtes Risiko), ab 50 Jahren",
+                                                                "Pneumokokken Indikationsschema (erhöhtes Risiko), ab 50 Jahren",
+                                                                "TOTRANSLATE",
+                                                                "TOTRANSLATE",
+                                                                "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Indikationsschema, Frühgeborene.<br>
+     */
+    PNEUMOKOKKEN_INDIKATIONSSCHEMA_FR_HGEBORENE("SCHEMA118",
+                                                "1.2.40.0.34.5.183",
+                                                "Pneumokokken Indikationsschema, Frühgeborene",
+                                                "Pneumokokken Indikationsschema, Frühgeborene",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung ab 3 Jahren.<br>
+     */
+    PNEUMOKOKKEN_INDIKATIONSSCHEMA_HOHES_RISIKO_ERSTIMPFUNG_AB_3_JAHREN("SCHEMA046",
+                                                                        "1.2.40.0.34.5.183",
+                                                                        "Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung ab 3 Jahren",
+                                                                        "Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung ab 3 Jahren",
+                                                                        "TOTRANSLATE",
+                                                                        "TOTRANSLATE",
+                                                                        "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung bis 1 Jahr.<br>
+     */
+    PNEUMOKOKKEN_INDIKATIONSSCHEMA_HOHES_RISIKO_ERSTIMPFUNG_BIS_1_JAHR("SCHEMA044",
+                                                                       "1.2.40.0.34.5.183",
+                                                                       "Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung bis 1 Jahr",
+                                                                       "Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung bis 1 Jahr",
+                                                                       "TOTRANSLATE",
+                                                                       "TOTRANSLATE",
+                                                                       "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung im 2. Lebensjahr.<br>
+     */
+    PNEUMOKOKKEN_INDIKATIONSSCHEMA_HOHES_RISIKO_ERSTIMPFUNG_IM_2_LEBENSJAHR("SCHEMA045",
+                                                                            "1.2.40.0.34.5.183",
+                                                                            "Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung im 2. Lebensjahr",
+                                                                            "Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung im 2. Lebensjahr",
+                                                                            "TOTRANSLATE",
+                                                                            "TOTRANSLATE",
+                                                                            "TOTRANSLATE"),
+    /**
+     * EN: Poliomyelitis Indikationsschema ab dem vollendeten 1. Lebensjahr.<br>
+     */
+    POLIOMYELITIS_INDIKATIONSSCHEMA_AB_DEM_VOLLENDETEN_1_LEBENSJAHR("SCHEMA120",
+                                                                    "1.2.40.0.34.5.183",
+                                                                    "Poliomyelitis Indikationsschema ab dem vollendeten 1. Lebensjahr",
+                                                                    "Poliomyelitis Indikationsschema ab dem vollendeten 1. Lebensjahr",
+                                                                    "TOTRANSLATE",
+                                                                    "TOTRANSLATE",
+                                                                    "TOTRANSLATE"),
+    /**
+     * EN: Poliomyelitis Indikationsschema ab dem vollendeten 2. Lebensmonat.<br>
+     */
+    POLIOMYELITIS_INDIKATIONSSCHEMA_AB_DEM_VOLLENDETEN_2_LEBENSMONAT("SCHEMA084",
+                                                                     "1.2.40.0.34.5.183",
+                                                                     "Poliomyelitis Indikationsschema ab dem vollendeten 2. Lebensmonat",
+                                                                     "Poliomyelitis Indikationsschema ab dem vollendeten 2. Lebensmonat",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus.<br>
+     */
+    ROTAVIRUS("SCHEMA244",
+              "1.2.40.0.34.5.183",
+              "Rotavirus",
+              "Rotavirus",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 20.-24. Lebenswoche, Rotarix.<br>
+     */
+    ROTAVIRUS_GRUNDSCHEMA_1_DOSIS_ERSTIMPFUNG_AB_DER_VOLLENDETEN_20_24_LEBENSWOCHE_ROTARIX("SCHEMA052",
+                                                                                           "1.2.40.0.34.5.183",
+                                                                                           "Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 20.-24. Lebenswoche, Rotarix",
+                                                                                           "Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 20.-24. Lebenswoche, Rotarix",
+                                                                                           "TOTRANSLATE",
+                                                                                           "TOTRANSLATE",
+                                                                                           "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 28.-32. Lebenswoche, Rotateq.<br>
+     */
+    ROTAVIRUS_GRUNDSCHEMA_1_DOSIS_ERSTIMPFUNG_AB_DER_VOLLENDETEN_28_32_LEBENSWOCHE_ROTATEQ("SCHEMA053",
+                                                                                           "1.2.40.0.34.5.183",
+                                                                                           "Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 28.-32. Lebenswoche, Rotateq",
+                                                                                           "Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 28.-32. Lebenswoche, Rotateq",
+                                                                                           "TOTRANSLATE",
+                                                                                           "TOTRANSLATE",
+                                                                                           "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 24.-28. Lebenswoche, Rotateq.<br>
+     */
+    ROTAVIRUS_GRUNDSCHEMA_2_DOSEN_ERSTIMPFUNG_AB_DER_VOLLENDETEN_24_28_LEBENSWOCHE_ROTATEQ("SCHEMA051",
+                                                                                           "1.2.40.0.34.5.183",
+                                                                                           "Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 24.-28. Lebenswoche, Rotateq",
+                                                                                           "Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 24.-28. Lebenswoche, Rotateq",
+                                                                                           "TOTRANSLATE",
+                                                                                           "TOTRANSLATE",
+                                                                                           "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 6.-20. Lebenswoche, Rotarix.<br>
+     */
+    ROTAVIRUS_GRUNDSCHEMA_2_DOSEN_ERSTIMPFUNG_AB_DER_VOLLENDETEN_6_20_LEBENSWOCHE_ROTARIX("SCHEMA050",
+                                                                                          "1.2.40.0.34.5.183",
+                                                                                          "Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 6.-20. Lebenswoche, Rotarix",
+                                                                                          "Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 6.-20. Lebenswoche, Rotarix",
+                                                                                          "TOTRANSLATE",
+                                                                                          "TOTRANSLATE",
+                                                                                          "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Grundschema, 3 Dosen, Erstimpfung ab der vollendeten 6.- 24. Lebenswoche, Rotateq.<br>
+     */
+    ROTAVIRUS_GRUNDSCHEMA_3_DOSEN_ERSTIMPFUNG_AB_DER_VOLLENDETEN_6_24_LEBENSWOCHE_ROTATEQ("SCHEMA054",
+                                                                                          "1.2.40.0.34.5.183",
+                                                                                          "Rotavirus Grundschema, 3 Dosen, Erstimpfung ab der vollendeten 6.- 24. Lebenswoche, Rotateq",
+                                                                                          "Rotavirus Grundschema, 3 Dosen, Erstimpfung ab der vollendeten 6.- 24. Lebenswoche, Rotateq",
+                                                                                          "TOTRANSLATE",
+                                                                                          "TOTRANSLATE",
+                                                                                          "TOTRANSLATE"),
+    /**
+     * EN: RSV.<br>
+     */
+    RSV("SCHEMA245",
+        "1.2.40.0.34.5.183",
+        "RSV",
+        "RSV",
+        "TOTRANSLATE",
+        "TOTRANSLATE",
+        "TOTRANSLATE"),
+    /**
+     * EN: RSV Grundschema.<br>
+     */
+    RSV_GRUNDSCHEMA("SCHEMA121",
+                    "1.2.40.0.34.5.183",
+                    "RSV Grundschema",
+                    "RSV Grundschema",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Grundschema, Auslandsimpfung.<br>
+     */
+    SARS_COV_2_GRUNDSCHEMA_AUSLANDSIMPFUNG("SCHEMA090",
+                                           "1.2.40.0.34.5.183",
+                                           "SARS-CoV-2 Grundschema, Auslandsimpfung",
+                                           "SARS-CoV-2 Grundschema, Auslandsimpfung",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Grundschema, Comirnaty.<br>
+     */
+    SARS_COV_2_GRUNDSCHEMA_COMIRNATY("SCHEMA086",
+                                     "1.2.40.0.34.5.183",
+                                     "SARS-CoV-2 Grundschema, Comirnaty",
+                                     "SARS-CoV-2 Grundschema, Comirnaty",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Grundschema, Jcovden.<br>
+     */
+    SARS_COV_2_GRUNDSCHEMA_JCOVDEN("SCHEMA089",
+                                   "1.2.40.0.34.5.183",
+                                   "SARS-CoV-2 Grundschema, Jcovden",
+                                   "SARS-CoV-2 Grundschema, Jcovden",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Grundschema, Nuvaxovid.<br>
+     */
+    SARS_COV_2_GRUNDSCHEMA_NUVAXOVID("SCHEMA099",
+                                     "1.2.40.0.34.5.183",
+                                     "SARS-CoV-2 Grundschema, Nuvaxovid",
+                                     "SARS-CoV-2 Grundschema, Nuvaxovid",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Grundschema, Spikevax.<br>
+     */
+    SARS_COV_2_GRUNDSCHEMA_SPIKEVAX("SCHEMA087",
+                                    "1.2.40.0.34.5.183",
+                                    "SARS-CoV-2 Grundschema, Spikevax",
+                                    "SARS-CoV-2 Grundschema, Spikevax",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Grundschema, Valneva.<br>
+     */
+    SARS_COV_2_GRUNDSCHEMA_VALNEVA("SCHEMA112",
+                                   "1.2.40.0.34.5.183",
+                                   "SARS-CoV-2 Grundschema, Valneva",
+                                   "SARS-CoV-2 Grundschema, Valneva",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE",
+                                   "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Grundschema, Vaxzevria.<br>
+     */
+    SARS_COV_2_GRUNDSCHEMA_VAXZEVRIA("SCHEMA088",
+                                     "1.2.40.0.34.5.183",
+                                     "SARS-CoV-2 Grundschema, Vaxzevria",
+                                     "SARS-CoV-2 Grundschema, Vaxzevria",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 heterologes Schema (Impfstoffwechsel).<br>
+     */
+    SARS_COV_2_HETEROLOGES_SCHEMA_IMPFSTOFFWECHSEL("SCHEMA096",
+                                                   "1.2.40.0.34.5.183",
+                                                   "SARS-CoV-2 heterologes Schema (Impfstoffwechsel)",
+                                                   "SARS-CoV-2 heterologes Schema (Impfstoffwechsel)",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE",
+                                                   "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Indikationsschema, Comirnaty.<br>
+     */
+    SARS_COV_2_INDIKATIONSSCHEMA_COMIRNATY("SCHEMA094",
+                                           "1.2.40.0.34.5.183",
+                                           "SARS-CoV-2 Indikationsschema, Comirnaty",
+                                           "SARS-CoV-2 Indikationsschema, Comirnaty",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: SARS-CoV-2 Indikationsschema, Spikevax.<br>
+     */
+    SARS_COV_2_INDIKATIONSSCHEMA_SPIKEVAX("SCHEMA095",
+                                          "1.2.40.0.34.5.183",
+                                          "SARS-CoV-2 Indikationsschema, Spikevax",
+                                          "SARS-CoV-2 Indikationsschema, Spikevax",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: 6-fach (2+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen.<br>
+     */
+    SIX_FACH_2_1_DI_TE_PERT_HIB_IPV_HEPB_INKL_AUFFRISCHUNGSIMPFUNGEN("SCHEMA201",
+                                                                     "1.2.40.0.34.5.183",
+                                                                     "6-fach (2+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen",
+                                                                     "6-fach (2+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE",
+                                                                     "TOTRANSLATE"),
+    /**
+     * EN: 6-fach (3+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen, Indikation.<br>
+     */
+    SIX_FACH_3_1_DI_TE_PERT_HIB_IPV_HEPB_INKL_AUFFRISCHUNGSIMPFUNGEN_INDIKATION("SCHEMA202",
+                                                                                "1.2.40.0.34.5.183",
+                                                                                "6-fach (3+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen, Indikation",
+                                                                                "6-fach (3+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen, Indikation",
+                                                                                "TOTRANSLATE",
+                                                                                "TOTRANSLATE",
+                                                                                "TOTRANSLATE"),
+    /**
+     * EN: Tetanus Monokomponente.<br>
+     */
+    TETANUS_MONOKOMPONENTE("SCHEMA083",
+                           "1.2.40.0.34.5.183",
+                           "Tetanus Monokomponente",
+                           "Tetanus Monokomponente",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Tollwut.<br>
+     */
+    TOLLWUT("SCHEMA246",
+            "1.2.40.0.34.5.183",
+            "Tollwut",
+            "Tollwut",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Grundschema.<br>
+     */
+    TOLLWUT_GRUNDSCHEMA("SCHEMA070",
+                        "1.2.40.0.34.5.183",
+                        "Tollwut Grundschema",
+                        "Tollwut Grundschema",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Tollwut postexpositionelles Schema, Essen 4 Dosen.<br>
+     */
+    TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_ESSEN_4_DOSEN("SCHEMA072",
+                                                     "1.2.40.0.34.5.183",
+                                                     "Tollwut postexpositionelles Schema, Essen 4 Dosen",
+                                                     "Tollwut postexpositionelles Schema, Essen 4 Dosen",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE"),
+    /**
+     * EN: Tollwut postexpositionelles Schema, Essen 5 Dosen.<br>
+     */
+    TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_ESSEN_5_DOSEN("SCHEMA073",
+                                                     "1.2.40.0.34.5.183",
+                                                     "Tollwut postexpositionelles Schema, Essen 5 Dosen",
+                                                     "Tollwut postexpositionelles Schema, Essen 5 Dosen",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE",
+                                                     "TOTRANSLATE"),
+    /**
+     * EN: Tollwut postexpositionelles Schema, mit Tollwut-Vorimpfung.<br>
+     */
+    TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_MIT_TOLLWUT_VORIMPFUNG("SCHEMA075",
+                                                              "1.2.40.0.34.5.183",
+                                                              "Tollwut postexpositionelles Schema, mit Tollwut-Vorimpfung",
+                                                              "Tollwut postexpositionelles Schema, mit Tollwut-Vorimpfung",
+                                                              "TOTRANSLATE",
+                                                              "TOTRANSLATE",
+                                                              "TOTRANSLATE"),
+    /**
+     * EN: Tollwut postexpositionelles Schema, Zagreb.<br>
+     */
+    TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_ZAGREB("SCHEMA074",
+                                              "1.2.40.0.34.5.183",
+                                              "Tollwut postexpositionelles Schema, Zagreb",
+                                              "Tollwut postexpositionelles Schema, Zagreb",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: Tollwut postexpositionell, Essen.<br>
+     */
+    TOLLWUT_POSTEXPOSITIONELL_ESSEN("SCHEMA247",
+                                    "1.2.40.0.34.5.183",
+                                    "Tollwut postexpositionell, Essen",
+                                    "Tollwut postexpositionell, Essen",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE",
+                                    "TOTRANSLATE"),
+    /**
+     * EN: Tollwut postexpositionell, mit Vorimpfung.<br>
+     */
+    TOLLWUT_POSTEXPOSITIONELL_MIT_VORIMPFUNG("SCHEMA248",
+                                             "1.2.40.0.34.5.183",
+                                             "Tollwut postexpositionell, mit Vorimpfung",
+                                             "Tollwut postexpositionell, mit Vorimpfung",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE"),
+    /**
+     * EN: Tollwut postexpositionell, Zagreb.<br>
+     */
+    TOLLWUT_POSTEXPOSITIONELL_ZAGREB("SCHEMA249",
+                                     "1.2.40.0.34.5.183",
+                                     "Tollwut postexpositionell, Zagreb",
+                                     "Tollwut postexpositionell, Zagreb",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Schnellschema.<br>
+     */
+    TOLLWUT_SCHNELLSCHEMA("SCHEMA071",
+                          "1.2.40.0.34.5.183",
+                          "Tollwut Schnellschema",
+                          "Tollwut Schnellschema",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Tollwut, Schnellschema.<br>
+     */
+    TOLLWUT_SCHNELLSCHEMA("SCHEMA250",
+                          "1.2.40.0.34.5.183",
+                          "Tollwut, Schnellschema",
+                          "Tollwut, Schnellschema",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Schnellschema (WHO).<br>
+     */
+    TOLLWUT_SCHNELLSCHEMA_WHO("SCHEMA123",
+                              "1.2.40.0.34.5.183",
+                              "Tollwut Schnellschema (WHO)",
+                              "Tollwut Schnellschema (WHO)",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Tollwut, Schnellschema (WHO).<br>
+     */
+    TOLLWUT_SCHNELLSCHEMA_WHO("SCHEMA251",
+                              "1.2.40.0.34.5.183",
+                              "Tollwut, Schnellschema (WHO)",
+                              "Tollwut, Schnellschema (WHO)",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Schnellschema (WHO), intradermal.<br>
+     */
+    TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL("SCHEMA124",
+                                          "1.2.40.0.34.5.183",
+                                          "Tollwut Schnellschema (WHO), intradermal",
+                                          "Tollwut Schnellschema (WHO), intradermal",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Tollwut, Schnellschema (WHO) intradermal.<br>
+     */
+    TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL("SCHEMA252",
+                                          "1.2.40.0.34.5.183",
+                                          "Tollwut, Schnellschema (WHO) intradermal",
+                                          "Tollwut, Schnellschema (WHO) intradermal",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Typhus.<br>
+     */
+    TYPHUS("SCHEMA253",
+           "1.2.40.0.34.5.183",
+           "Typhus",
+           "Typhus",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: Typhus Grundschema, Injektion.<br>
+     */
+    TYPHUS_GRUNDSCHEMA_INJEKTION("SCHEMA068",
+                                 "1.2.40.0.34.5.183",
+                                 "Typhus Grundschema, Injektion",
+                                 "Typhus Grundschema, Injektion",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Typhus Grundschema, Oral.<br>
+     */
+    TYPHUS_GRUNDSCHEMA_ORAL("SCHEMA069",
+                            "1.2.40.0.34.5.183",
+                            "Typhus Grundschema, Oral",
+                            "Typhus Grundschema, Oral",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Varizellen.<br>
+     */
+    VARIZELLEN("SCHEMA254",
+               "1.2.40.0.34.5.183",
+               "Varizellen",
+               "Varizellen",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Varizellen Grundschema, ab 1 Jahr.<br>
+     */
+    VARIZELLEN_GRUNDSCHEMA_AB_1_JAHR("SCHEMA060",
+                                     "1.2.40.0.34.5.183",
+                                     "Varizellen Grundschema, ab 1 Jahr",
+                                     "Varizellen Grundschema, ab 1 Jahr",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE",
+                                     "TOTRANSLATE"),
+    /**
+     * EN: Varizellen, Indikation.<br>
+     */
+    VARIZELLEN_INDIKATION("SCHEMA255",
+                          "1.2.40.0.34.5.183",
+                          "Varizellen, Indikation",
+                          "Varizellen, Indikation",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Varizellen Indikationsschema, Erstimpfung bis 1 Jahr.<br>
+     */
+    VARIZELLEN_INDIKATIONSSCHEMA_ERSTIMPFUNG_BIS_1_JAHR("SCHEMA063",
+                                                        "1.2.40.0.34.5.183",
+                                                        "Varizellen Indikationsschema, Erstimpfung bis 1 Jahr",
+                                                        "Varizellen Indikationsschema, Erstimpfung bis 1 Jahr",
+                                                        "TOTRANSLATE",
+                                                        "TOTRANSLATE",
+                                                        "TOTRANSLATE"),
+    /**
+     * EN: Zoonotische Influenza (H5N8).<br>
+     */
+    ZOONOTISCHE_INFLUENZA_H5N8("SCHEMA257",
+                               "1.2.40.0.34.5.183",
+                               "Zoonotische Influenza (H5N8)",
+                               "Zoonotische Influenza (H5N8)",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE");
+
+    /**
+     * EN: Code for Chikungunya.<br>
+     */
+    public static final String CHIKUNGUNYA_CODE = "SCHEMA256";
+
+    /**
+     * EN: Code for Cholera.<br>
+     */
+    public static final String CHOLERA_CODE = "SCHEMA203";
+
+    /**
+     * EN: Code for Cholera Grundschema, Erstimpfung 2-6 Jahre.<br>
+     */
+    public static final String CHOLERA_GRUNDSCHEMA_ERSTIMPFUNG_2_6_JAHRE_CODE = "SCHEMA076";
+
+    /**
+     * EN: Code for Cholera Grundschema, Erstimpfung ab 6 Jahren.<br>
+     */
+    public static final String CHOLERA_GRUNDSCHEMA_ERSTIMPFUNG_AB_6_JAHREN_CODE = "SCHEMA078";
+
+    /**
+     * EN: Code for COVID-19.<br>
+     */
+    public static final String COVID_19_CODE = "SCHEMA204";
+
+    /**
+     * EN: Code for COVID-19 Grundschema.<br>
+     */
+    public static final String COVID_19_GRUNDSCHEMA_CODE = "SCHEMA122";
+
+    /**
+     * EN: Code for COVID-19 Grundschema, Kleinkind.<br>
+     */
+    public static final String COVID_19_GRUNDSCHEMA_KLEINKIND_CODE = "SCHEMA117";
+
+    /**
+     * EN: Code for COVID-19, Indikation.<br>
+     */
+    public static final String COVID_19_INDIKATION_CODE = "SCHEMA205";
+
+    /**
+     * EN: Code for COVID-19 Indikationsschema.<br>
+     */
+    public static final String COVID_19_INDIKATIONSSCHEMA_CODE = "SCHEMA110";
+
+    /**
+     * EN: Code for COVID-19, Indikation Grundimmunisierung bis 5 Jahre.<br>
+     */
+    public static final String COVID_19_INDIKATION_GRUNDIMMUNISIERUNG_BIS_5_JAHRE_CODE = "SCHEMA260";
+
+    /**
+     * EN: Code for Dengue.<br>
+     */
+    public static final String DENGUE_CODE = "SCHEMA206";
+
+    /**
+     * EN: Code for Dengue-Fieber Grundschema, 2 Dosen.<br>
+     */
+    public static final String DENGUE_FIEBER_GRUNDSCHEMA_2_DOSEN_CODE = "SCHEMA119";
+
+    /**
+     * EN: Code for Di-Te-Pert.<br>
+     */
+    public static final String DI_TE_PERT_CODE = "SCHEMA207";
+
+    /**
+     * EN: Code for Di-Te-Pert-IPV.<br>
+     */
+    public static final String DI_TE_PERT_IPV_CODE = "SCHEMA208";
+
+    /**
+     * EN: Code for Di-Te-Pert-IPV, Indikation.<br>
+     */
+    public static final String DI_TE_PERT_IPV_INDIKATION_CODE = "SCHEMA259";
+
+    /**
+     * EN: Code for FSME.<br>
+     */
+    public static final String FSME_CODE = "SCHEMA209";
+
+    /**
+     * EN: Code for FSME, beschleunigtes konventionelles Schema.<br>
+     */
+    public static final String FSME_BESCHLEUNIGTES_KONVENTIONELLES_SCHEMA_CODE = "SCHEMA210";
+
+    /**
+     * EN: Code for FSME beschleunigtes konventionelles Schema, Encepur.<br>
+     */
+    public static final String FSME_BESCHLEUNIGTES_KONVENTIONELLES_SCHEMA_ENCEPUR_CODE = "SCHEMA126";
+
+    /**
+     * EN: Code for FSME Grundschema, Encepur.<br>
+     */
+    public static final String FSME_GRUNDSCHEMA_ENCEPUR_CODE = "SCHEMA006";
+
+    /**
+     * EN: Code for FSME Grundschema, Encepur, Erstimpfung bis 1 Jahr.<br>
+     */
+    public static final String FSME_GRUNDSCHEMA_ENCEPUR_ERSTIMPFUNG_BIS_1_JAHR_CODE = "SCHEMA008";
+
+    /**
+     * EN: Code for FSME Grundschema, FSME-Immun.<br>
+     */
+    public static final String FSME_GRUNDSCHEMA_FSME_IMMUN_CODE = "SCHEMA005";
+
+    /**
+     * EN: Code for FSME Grundschema, FSME-Immun, Erstimpfung bis 1 Jahr.<br>
+     */
+    public static final String FSME_GRUNDSCHEMA_FSME_IMMUN_ERSTIMPFUNG_BIS_1_JAHR_CODE = "SCHEMA007";
+
+    /**
+     * EN: Code for FSME, Schnellschema.<br>
+     */
+    public static final String FSME_SCHNELLSCHEMA_CODE = "SCHEMA211";
+
+    /**
+     * EN: Code for FSME Schnellschema, Encepur.<br>
+     */
+    public static final String FSME_SCHNELLSCHEMA_ENCEPUR_CODE = "SCHEMA010";
+
+    /**
+     * EN: Code for FSME Schnellschema, FSME-Immun.<br>
+     */
+    public static final String FSME_SCHNELLSCHEMA_FSME_IMMUN_CODE = "SCHEMA009";
+
+    /**
+     * EN: Code for Gelbfieber.<br>
+     */
+    public static final String GELBFIEBER_CODE = "SCHEMA212";
+
+    /**
+     * EN: Code for Gelbfieber Grundschema, ab dem vollendeten 9. Lebensmonat.<br>
+     */
+    public static final String GELBFIEBER_GRUNDSCHEMA_AB_DEM_VOLLENDETEN_9_LEBENSMONAT_CODE = "SCHEMA065";
+
+    /**
+     * EN: Code for Haemophilus influenzae Typ B Indikationsschema.<br>
+     */
+    public static final String HAEMOPHILUS_INFLUENZAE_TYP_B_INDIKATIONSSCHEMA_CODE = "SCHEMA011";
+
+    /**
+     * EN: Code for Hepatitis A.<br>
+     */
+    public static final String HEPATITIS_A_CODE = "SCHEMA213";
+
+    /**
+     * EN: Code for Hepatitis AB.<br>
+     */
+    public static final String HEPATITIS_AB_CODE = "SCHEMA215";
+
+    /**
+     * EN: Code for Hepatitis AB Grundschema.<br>
+     */
+    public static final String HEPATITIS_AB_GRUNDSCHEMA_CODE = "SCHEMA013";
+
+    /**
+     * EN: Code for Hepatitis AB Schnellschema.<br>
+     */
+    public static final String HEPATITIS_AB_SCHNELLSCHEMA_CODE = "SCHEMA015";
+
+    /**
+     * EN: Code for Hepatitis AB, Schnellschema.<br>
+     */
+    public static final String HEPATITIS_AB_SCHNELLSCHEMA_CODE = "SCHEMA258";
+
+    /**
+     * EN: Code for Hepatitis A Monokomponente Grundschema.<br>
+     */
+    public static final String HEPATITIS_A_MONOKOMPONENTE_GRUNDSCHEMA_CODE = "SCHEMA014";
+
+    /**
+     * EN: Code for Hepatitis A Monokomponente Indikationsschema.<br>
+     */
+    public static final String HEPATITIS_A_MONOKOMPONENTE_INDIKATIONSSCHEMA_CODE = "SCHEMA012";
+
+    /**
+     * EN: Code for Hepatitis A &amp; Typhus Grundschema.<br>
+     */
+    public static final String HEPATITIS_A_TYPHUS_GRUNDSCHEMA_CODE = "SCHEMA016";
+
+    /**
+     * EN: Code for Hepatitis B.<br>
+     */
+    public static final String HEPATITIS_B_CODE = "SCHEMA216";
+
+    /**
+     * EN: Code for Hepatitis B, Indikation.<br>
+     */
+    public static final String HEPATITIS_B_INDIKATION_CODE = "SCHEMA217";
+
+    /**
+     * EN: Code for Hepatitis B, Indikation Prophylaxe Neugeborener.<br>
+     */
+    public static final String HEPATITIS_B_INDIKATION_PROPHYLAXE_NEUGEBORENER_CODE = "SCHEMA218";
+
+    /**
+     * EN: Code for Hepatitis B Monokomponente Grundschema.<br>
+     */
+    public static final String HEPATITIS_B_MONOKOMPONENTE_GRUNDSCHEMA_CODE = "SCHEMA017";
+
+    /**
+     * EN: Code for Hepatitis B Monokomponente Indikationsschema.<br>
+     */
+    public static final String HEPATITIS_B_MONOKOMPONENTE_INDIKATIONSSCHEMA_CODE = "SCHEMA085";
+
+    /**
+     * EN: Code for Hepatitis B Monokomponente Schnellschema durch Indikation.<br>
+     */
+    public static final String HEPATITIS_B_MONOKOMPONENTE_SCHNELLSCHEMA_DURCH_INDIKATION_CODE = "SCHEMA102";
+
+    /**
+     * EN: Code for Hepatitis B Non-/Low-Responder Indikationsschema.<br>
+     */
+    public static final String HEPATITIS_B_NON_LOW_RESPONDER_INDIKATIONSSCHEMA_CODE = "SCHEMA019";
+
+    /**
+     * EN: Code for Hepatitis B Prophylaxe Neugeborener Indikationsschema.<br>
+     */
+    public static final String HEPATITIS_B_PROPHYLAXE_NEUGEBORENER_INDIKATIONSSCHEMA_CODE = "SCHEMA103";
+
+    /**
+     * EN: Code for Hepatitis B, Schnellschema.<br>
+     */
+    public static final String HEPATITIS_B_SCHNELLSCHEMA_CODE = "SCHEMA219";
+
+    /**
+     * EN: Code for Herpes Zoster.<br>
+     */
+    public static final String HERPES_ZOSTER_CODE = "SCHEMA220";
+
+    /**
+     * EN: Code for Herpes Zoster Grundschema, ab 50 Jahren.<br>
+     */
+    public static final String HERPES_ZOSTER_GRUNDSCHEMA_AB_50_JAHREN_CODE = "SCHEMA064";
+
+    /**
+     * EN: Code for Herpes Zoster Grundschema, nach Zostavax.<br>
+     */
+    public static final String HERPES_ZOSTER_GRUNDSCHEMA_NACH_ZOSTAVAX_CODE = "SCHEMA091";
+
+    /**
+     * EN: Code for Herpes Zoster, Indikation.<br>
+     */
+    public static final String HERPES_ZOSTER_INDIKATION_CODE = "SCHEMA221";
+
+    /**
+     * EN: Code for Herpes Zoster Indikationsschema, ab 18 Jahren.<br>
+     */
+    public static final String HERPES_ZOSTER_INDIKATIONSSCHEMA_AB_18_JAHREN_CODE = "SCHEMA092";
+
+    /**
+     * EN: Code for HiB, Indikation.<br>
+     */
+    public static final String HIB_INDIKATION_CODE = "SCHEMA222";
+
+    /**
+     * EN: Code for HPV.<br>
+     */
+    public static final String HPV_CODE = "SCHEMA223";
+
+    /**
+     * EN: Code for HPV Grundschema.<br>
+     */
+    public static final String HPV_GRUNDSCHEMA_CODE = "SCHEMA020";
+
+    /**
+     * EN: Code for HPV Grundschema, ab 21 Jahren.<br>
+     */
+    public static final String HPV_GRUNDSCHEMA_AB_21_JAHREN_CODE = "SCHEMA021";
+
+    /**
+     * EN: Code for HPV, Indikation.<br>
+     */
+    public static final String HPV_INDIKATION_CODE = "SCHEMA224";
+
+    /**
+     * EN: Code for HPV Indikationsschema.<br>
+     */
+    public static final String HPV_INDIKATIONSSCHEMA_CODE = "SCHEMA022";
+
+    /**
+     * EN: Code for Influenza.<br>
+     */
+    public static final String INFLUENZA_CODE = "SCHEMA225";
+
+    /**
+     * EN: Code for Influenza Grundschema, Einmalimpfung.<br>
+     */
+    public static final String INFLUENZA_GRUNDSCHEMA_EINMALIMPFUNG_CODE = "SCHEMA024";
+
+    /**
+     * EN: Code for Influenza Grundschema, Erstimpfung Kinder.<br>
+     */
+    public static final String INFLUENZA_GRUNDSCHEMA_ERSTIMPFUNG_KINDER_CODE = "SCHEMA023";
+
+    /**
+     * EN: Code for Influenza, Indikation.<br>
+     */
+    public static final String INFLUENZA_INDIKATION_CODE = "SCHEMA226";
+
+    /**
+     * EN: Code for Influenza Indikationsschema.<br>
+     */
+    public static final String INFLUENZA_INDIKATIONSSCHEMA_CODE = "SCHEMA104";
+
+    /**
+     * EN: Code for Japanische Enzephalitis.<br>
+     */
+    public static final String JAPANISCHE_ENZEPHALITIS_CODE = "SCHEMA227";
+
+    /**
+     * EN: Code for Japanische Enzephalitis Grundschema, ab 2 Monaten.<br>
+     */
+    public static final String JAPANISCHE_ENZEPHALITIS_GRUNDSCHEMA_AB_2_MONATEN_CODE = "SCHEMA066";
+
+    /**
+     * EN: Code for Japanische Enzephalitis, Schnellschema.<br>
+     */
+    public static final String JAPANISCHE_ENZEPHALITIS_SCHNELLSCHEMA_CODE = "SCHEMA228";
+
+    /**
+     * EN: Code for Japanische Enzephalitis Schnellschema, ab 18 Jahren.<br>
+     */
+    public static final String JAPANISCHE_ENZEPHALITIS_SCHNELLSCHEMA_AB_18_JAHREN_CODE = "SCHEMA067";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_CODE = "SCHEMA082";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te-IPV.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_IPV_CODE = "SCHEMA105";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te-Pert.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_PERT_CODE = "SCHEMA081";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung ab 1 Jahr.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_PERT_HIB_IPV_HEPB_ERSTIMPFUNG_AB_1_JAHR_CODE = "SCHEMA002";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Erstimpfung bis 1 Jahr.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_PERT_HIB_IPV_HEPB_ERSTIMPFUNG_BIS_1_JAHR_CODE = "SCHEMA001";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te-Pert-HiB-IPV-HepB, Indikation.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_PERT_HIB_IPV_HEPB_INDIKATION_CODE = "SCHEMA004";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te-Pert-IPV.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_PERT_IPV_CODE = "SCHEMA080";
+
+    /**
+     * EN: Code for Kombinationsschema Di-Te-Pert-IPV-HepB, Erstimpfung ab 6 Jahren.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_DI_TE_PERT_IPV_HEPB_ERSTIMPFUNG_AB_6_JAHREN_CODE = "SCHEMA003";
+
+    /**
+     * EN: Code for Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMRV.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_MMRV_AB_12_MONATEN_MMRV_MMRV_CODE = "SCHEMA101";
+
+    /**
+     * EN: Code for Kombinationsschema MMRV, ab 12 Monaten, MMRV - MMR - V.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_MMRV_AB_12_MONATEN_MMRV_MMR_V_CODE = "SCHEMA114";
+
+    /**
+     * EN: Code for Kombinationsschema MMRV, ab 12 Monaten, MMR - MMRV - V.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_MMRV_AB_12_MONATEN_MMR_MMRV_V_CODE = "SCHEMA062";
+
+    /**
+     * EN: Code for Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMRV.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_MMRV_AB_9_MONATEN_MMRV_MMRV_CODE = "SCHEMA100";
+
+    /**
+     * EN: Code for Kombinationsschema MMRV, ab 9 Monaten, MMRV - MMR - V.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_MMRV_AB_9_MONATEN_MMRV_MMR_V_CODE = "SCHEMA113";
+
+    /**
+     * EN: Code for Kombinationsschema MMRV, ab 9 Monaten, MMR - MMRV - V.<br>
+     */
+    public static final String KOMBINATIONSSCHEMA_MMRV_AB_9_MONATEN_MMR_MMRV_V_CODE = "SCHEMA061";
+
+    /**
+     * EN: Code for Meningokokken ACWY.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_CODE = "SCHEMA229";
+
+    /**
+     * EN: Code for Meningokokken ACWY, ab 1 Jahr.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_AB_1_JAHR_CODE = "SCHEMA125";
+
+    /**
+     * EN: Code for Meningokokken ACWY Grundschema, ab 10 Jahren.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_GRUNDSCHEMA_AB_10_JAHREN_CODE = "SCHEMA039";
+
+    /**
+     * EN: Code for Meningokokken ACWY, Indikation.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_INDIKATION_CODE = "SCHEMA230";
+
+    /**
+     * EN: Code for Meningokokken ACWY Indikationsschema, ab 1 Jahr.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_AB_1_JAHR_CODE = "SCHEMA040";
+
+    /**
+     * EN: Code for Meningokokken ACWY Indikationsschema, Erstimpfung bis 1 Jahr.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_ERSTIMPFUNG_BIS_1_JAHR_CODE = "SCHEMA041";
+
+    /**
+     * EN: Code for Meningokokken ACWY Indikationsschema, Menveo ab 2 Jahre.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_MENVEO_AB_2_JAHRE_CODE = "SCHEMA109";
+
+    /**
+     * EN: Code for Meningokokken ACWY Indikationsschema, Nimenrix ab 1 Jahr.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_NIMENRIX_AB_1_JAHR_CODE = "SCHEMA108";
+
+    /**
+     * EN: Code for Meningokokken ACWY Indikationsschema, Nimenrix ab 6 Monate.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_NIMENRIX_AB_6_MONATE_CODE = "SCHEMA107";
+
+    /**
+     * EN: Code for Meningokokken ACWY Indikationsschema, Nimenrix bis 6 Monate.<br>
+     */
+    public static final String MENINGOKOKKEN_ACWY_INDIKATIONSSCHEMA_NIMENRIX_BIS_6_MONATE_CODE = "SCHEMA106";
+
+    /**
+     * EN: Code for Meningokokken B.<br>
+     */
+    public static final String MENINGOKOKKEN_B_CODE = "SCHEMA231";
+
+    /**
+     * EN: Code for Meningokokken B Grundschema, Erstimpfung 10-25 Jahre, Trumenba.<br>
+     */
+    public static final String MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_10_25_JAHRE_TRUMENBA_CODE = "SCHEMA079";
+
+    /**
+     * EN: Code for Meningokokken B Grundschema, Erstimpfung 12-23 Monate.<br>
+     */
+    public static final String MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_12_23_MONATE_CODE = "SCHEMA031";
+
+    /**
+     * EN: Code for Meningokokken B Grundschema, Erstimpfung 2-25 Jahre, Bexsero.<br>
+     */
+    public static final String MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_2_25_JAHRE_BEXSERO_CODE = "SCHEMA032";
+
+    /**
+     * EN: Code for Meningokokken B Grundschema, Erstimpfung 2-5 Monate.<br>
+     */
+    public static final String MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_2_5_MONATE_CODE = "SCHEMA029";
+
+    /**
+     * EN: Code for Meningokokken B Grundschema, Erstimpfung 2-5 Monate, 4 Dosen.<br>
+     */
+    public static final String MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_2_5_MONATE_4_DOSEN_CODE = "SCHEMA028";
+
+    /**
+     * EN: Code for Meningokokken B Grundschema, Erstimpfung 6-11 Monate.<br>
+     */
+    public static final String MENINGOKOKKEN_B_GRUNDSCHEMA_ERSTIMPFUNG_6_11_MONATE_CODE = "SCHEMA030";
+
+    /**
+     * EN: Code for Meningokokken B, Indikation.<br>
+     */
+    public static final String MENINGOKOKKEN_B_INDIKATION_CODE = "SCHEMA232";
+
+    /**
+     * EN: Code for Meningokokken B Indikationsschema, ab 25 Jahren, Bexsero.<br>
+     */
+    public static final String MENINGOKOKKEN_B_INDIKATIONSSCHEMA_AB_25_JAHREN_BEXSERO_CODE = "SCHEMA033";
+
+    /**
+     * EN: Code for Meningokokken B Indikationsschema, ab 25 Jahren, Trumenba.<br>
+     */
+    public static final String MENINGOKOKKEN_B_INDIKATIONSSCHEMA_AB_25_JAHREN_TRUMENBA_CODE = "SCHEMA034";
+
+    /**
+     * EN: Code for Meningokokken C.<br>
+     */
+    public static final String MENINGOKOKKEN_C_CODE = "SCHEMA233";
+
+    /**
+     * EN: Code for Meningokokken C Grundschema, ab 1 Jahr.<br>
+     */
+    public static final String MENINGOKOKKEN_C_GRUNDSCHEMA_AB_1_JAHR_CODE = "SCHEMA038";
+
+    /**
+     * EN: Code for Meningokokken C Indikationsschema, 2-12 Monate, Menjugate.<br>
+     */
+    public static final String MENINGOKOKKEN_C_INDIKATIONSSCHEMA_2_12_MONATE_MENJUGATE_CODE = "SCHEMA036";
+
+    /**
+     * EN: Code for Meningokokken C Indikationsschema, 2-4 Monate, Neisvac C.<br>
+     */
+    public static final String MENINGOKOKKEN_C_INDIKATIONSSCHEMA_2_4_MONATE_NEISVAC_C_CODE = "SCHEMA035";
+
+    /**
+     * EN: Code for Meningokokken C Indikationsschema, 4-12 Monate, Neisvac C.<br>
+     */
+    public static final String MENINGOKOKKEN_C_INDIKATIONSSCHEMA_4_12_MONATE_NEISVAC_C_CODE = "SCHEMA037";
+
+    /**
+     * EN: Code for MMR.<br>
+     */
+    public static final String MMR_CODE = "SCHEMA234";
+
+    /**
+     * EN: Code for MMRV.<br>
+     */
+    public static final String MMRV_CODE = "SCHEMA237";
+
+    /**
+     * EN: Code for MMR Grundschema, ab 1 Jahr.<br>
+     */
+    public static final String MMR_GRUNDSCHEMA_AB_1_JAHR_CODE = "SCHEMA093";
+
+    /**
+     * EN: Code for MMR Grundschema ab 9 Monaten.<br>
+     */
+    public static final String MMR_GRUNDSCHEMA_AB_9_MONATEN_CODE = "SCHEMA025";
+
+    /**
+     * EN: Code for MMR, Indikation.<br>
+     */
+    public static final String MMR_INDIKATION_CODE = "SCHEMA236";
+
+    /**
+     * EN: Code for MMR Indikationsschema, Erstimpfung 6-8 Monate.<br>
+     */
+    public static final String MMR_INDIKATIONSSCHEMA_ERSTIMPFUNG_6_8_MONATE_CODE = "SCHEMA027";
+
+    /**
+     * EN: Code for MMR - MMRV - V.<br>
+     */
+    public static final String MMR_MMRV_V_CODE = "SCHEMA235";
+
+    /**
+     * EN: Code for Mpox.<br>
+     */
+    public static final String MPOX_CODE = "SCHEMA238";
+
+    /**
+     * EN: Code for Mpox/Pocken Indikationsschema.<br>
+     */
+    public static final String MPOX_POCKEN_INDIKATIONSSCHEMA_CODE = "SCHEMA111";
+
+    /**
+     * EN: Code for Mpox/Pocken Indikationsschema, einmalige Impfung.<br>
+     */
+    public static final String MPOX_POCKEN_INDIKATIONSSCHEMA_EINMALIGE_IMPFUNG_CODE = "SCHEMA115";
+
+    /**
+     * EN: Code for Pneumokokken.<br>
+     */
+    public static final String PNEUMOKOKKEN_CODE = "SCHEMA239";
+
+    /**
+     * EN: Code for Pneumokokken, Frühgeborene (3+1).<br>
+     */
+    public static final String PNEUMOKOKKEN_FR_HGEBORENE_3_1_CODE = "SCHEMA241";
+
+    /**
+     * EN: Code for Pneumokokken, Frühgeborene mit Indikation (3+1).<br>
+     */
+    public static final String PNEUMOKOKKEN_FR_HGEBORENE_MIT_INDIKATION_3_1_CODE = "SCHEMA243";
+
+    /**
+     * EN: Code for Pneumokokken Grundschema, ab 60 Jahre.<br>
+     */
+    public static final String PNEUMOKOKKEN_GRUNDSCHEMA_AB_60_JAHRE_CODE = "SCHEMA098";
+
+    /**
+     * EN: Code for Pneumokokken Grundschema, Erstimpfung 1-2 Jahre.<br>
+     */
+    public static final String PNEUMOKOKKEN_GRUNDSCHEMA_ERSTIMPFUNG_1_2_JAHRE_CODE = "SCHEMA043";
+
+    /**
+     * EN: Code for Pneumokokken Grundschema, Erstimpfung 2-5 Jahre.<br>
+     */
+    public static final String PNEUMOKOKKEN_GRUNDSCHEMA_ERSTIMPFUNG_2_5_JAHRE_CODE = "SCHEMA097";
+
+    /**
+     * EN: Code for Pneumokokken Grundschema, Erstimpfung bis 1 Jahr.<br>
+     */
+    public static final String PNEUMOKOKKEN_GRUNDSCHEMA_ERSTIMPFUNG_BIS_1_JAHR_CODE = "SCHEMA042";
+
+    /**
+     * EN: Code for Pneumokokken, Indikation.<br>
+     */
+    public static final String PNEUMOKOKKEN_INDIKATION_CODE = "SCHEMA242";
+
+    /**
+     * EN: Code for Pneumokokken Indikationsschema (erhöhtes Risiko), ab 50 Jahren.<br>
+     */
+    public static final String PNEUMOKOKKEN_INDIKATIONSSCHEMA_ERH_HTES_RISIKO_AB_50_JAHREN_CODE = "SCHEMA116";
+
+    /**
+     * EN: Code for Pneumokokken Indikationsschema, Frühgeborene.<br>
+     */
+    public static final String PNEUMOKOKKEN_INDIKATIONSSCHEMA_FR_HGEBORENE_CODE = "SCHEMA118";
+
+    /**
+     * EN: Code for Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung ab 3 Jahren.<br>
+     */
+    public static final String PNEUMOKOKKEN_INDIKATIONSSCHEMA_HOHES_RISIKO_ERSTIMPFUNG_AB_3_JAHREN_CODE = "SCHEMA046";
+
+    /**
+     * EN: Code for Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung bis 1 Jahr.<br>
+     */
+    public static final String PNEUMOKOKKEN_INDIKATIONSSCHEMA_HOHES_RISIKO_ERSTIMPFUNG_BIS_1_JAHR_CODE = "SCHEMA044";
+
+    /**
+     * EN: Code for Pneumokokken Indikationsschema (hohes Risiko), Erstimpfung im 2. Lebensjahr.<br>
+     */
+    public static final String PNEUMOKOKKEN_INDIKATIONSSCHEMA_HOHES_RISIKO_ERSTIMPFUNG_IM_2_LEBENSJAHR_CODE = "SCHEMA045";
+
+    /**
+     * EN: Code for Poliomyelitis Indikationsschema ab dem vollendeten 1. Lebensjahr.<br>
+     */
+    public static final String POLIOMYELITIS_INDIKATIONSSCHEMA_AB_DEM_VOLLENDETEN_1_LEBENSJAHR_CODE = "SCHEMA120";
+
+    /**
+     * EN: Code for Poliomyelitis Indikationsschema ab dem vollendeten 2. Lebensmonat.<br>
+     */
+    public static final String POLIOMYELITIS_INDIKATIONSSCHEMA_AB_DEM_VOLLENDETEN_2_LEBENSMONAT_CODE = "SCHEMA084";
+
+    /**
+     * EN: Code for Rotavirus.<br>
+     */
+    public static final String ROTAVIRUS_CODE = "SCHEMA244";
+
+    /**
+     * EN: Code for Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 20.-24. Lebenswoche, Rotarix.<br>
+     */
+    public static final String ROTAVIRUS_GRUNDSCHEMA_1_DOSIS_ERSTIMPFUNG_AB_DER_VOLLENDETEN_20_24_LEBENSWOCHE_ROTARIX_CODE = "SCHEMA052";
+
+    /**
+     * EN: Code for Rotavirus Grundschema, 1 Dosis, Erstimpfung ab der vollendeten 28.-32. Lebenswoche, Rotateq.<br>
+     */
+    public static final String ROTAVIRUS_GRUNDSCHEMA_1_DOSIS_ERSTIMPFUNG_AB_DER_VOLLENDETEN_28_32_LEBENSWOCHE_ROTATEQ_CODE = "SCHEMA053";
+
+    /**
+     * EN: Code for Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 24.-28. Lebenswoche, Rotateq.<br>
+     */
+    public static final String ROTAVIRUS_GRUNDSCHEMA_2_DOSEN_ERSTIMPFUNG_AB_DER_VOLLENDETEN_24_28_LEBENSWOCHE_ROTATEQ_CODE = "SCHEMA051";
+
+    /**
+     * EN: Code for Rotavirus Grundschema, 2 Dosen, Erstimpfung ab der vollendeten 6.-20. Lebenswoche, Rotarix.<br>
+     */
+    public static final String ROTAVIRUS_GRUNDSCHEMA_2_DOSEN_ERSTIMPFUNG_AB_DER_VOLLENDETEN_6_20_LEBENSWOCHE_ROTARIX_CODE = "SCHEMA050";
+
+    /**
+     * EN: Code for Rotavirus Grundschema, 3 Dosen, Erstimpfung ab der vollendeten 6.- 24. Lebenswoche, Rotateq.<br>
+     */
+    public static final String ROTAVIRUS_GRUNDSCHEMA_3_DOSEN_ERSTIMPFUNG_AB_DER_VOLLENDETEN_6_24_LEBENSWOCHE_ROTATEQ_CODE = "SCHEMA054";
+
+    /**
+     * EN: Code for RSV.<br>
+     */
+    public static final String RSV_CODE = "SCHEMA245";
+
+    /**
+     * EN: Code for RSV Grundschema.<br>
+     */
+    public static final String RSV_GRUNDSCHEMA_CODE = "SCHEMA121";
+
+    /**
+     * EN: Code for SARS-CoV-2 Grundschema, Auslandsimpfung.<br>
+     */
+    public static final String SARS_COV_2_GRUNDSCHEMA_AUSLANDSIMPFUNG_CODE = "SCHEMA090";
+
+    /**
+     * EN: Code for SARS-CoV-2 Grundschema, Comirnaty.<br>
+     */
+    public static final String SARS_COV_2_GRUNDSCHEMA_COMIRNATY_CODE = "SCHEMA086";
+
+    /**
+     * EN: Code for SARS-CoV-2 Grundschema, Jcovden.<br>
+     */
+    public static final String SARS_COV_2_GRUNDSCHEMA_JCOVDEN_CODE = "SCHEMA089";
+
+    /**
+     * EN: Code for SARS-CoV-2 Grundschema, Nuvaxovid.<br>
+     */
+    public static final String SARS_COV_2_GRUNDSCHEMA_NUVAXOVID_CODE = "SCHEMA099";
+
+    /**
+     * EN: Code for SARS-CoV-2 Grundschema, Spikevax.<br>
+     */
+    public static final String SARS_COV_2_GRUNDSCHEMA_SPIKEVAX_CODE = "SCHEMA087";
+
+    /**
+     * EN: Code for SARS-CoV-2 Grundschema, Valneva.<br>
+     */
+    public static final String SARS_COV_2_GRUNDSCHEMA_VALNEVA_CODE = "SCHEMA112";
+
+    /**
+     * EN: Code for SARS-CoV-2 Grundschema, Vaxzevria.<br>
+     */
+    public static final String SARS_COV_2_GRUNDSCHEMA_VAXZEVRIA_CODE = "SCHEMA088";
+
+    /**
+     * EN: Code for SARS-CoV-2 heterologes Schema (Impfstoffwechsel).<br>
+     */
+    public static final String SARS_COV_2_HETEROLOGES_SCHEMA_IMPFSTOFFWECHSEL_CODE = "SCHEMA096";
+
+    /**
+     * EN: Code for SARS-CoV-2 Indikationsschema, Comirnaty.<br>
+     */
+    public static final String SARS_COV_2_INDIKATIONSSCHEMA_COMIRNATY_CODE = "SCHEMA094";
+
+    /**
+     * EN: Code for SARS-CoV-2 Indikationsschema, Spikevax.<br>
+     */
+    public static final String SARS_COV_2_INDIKATIONSSCHEMA_SPIKEVAX_CODE = "SCHEMA095";
+
+    /**
+     * EN: Code for 6-fach (2+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen.<br>
+     */
+    public static final String SIX_FACH_2_1_DI_TE_PERT_HIB_IPV_HEPB_INKL_AUFFRISCHUNGSIMPFUNGEN_CODE = "SCHEMA201";
+
+    /**
+     * EN: Code for 6-fach (3+1) Di-Te-Pert-HiB-IPV-HepB inkl. Auffrischungsimpfungen, Indikation.<br>
+     */
+    public static final String SIX_FACH_3_1_DI_TE_PERT_HIB_IPV_HEPB_INKL_AUFFRISCHUNGSIMPFUNGEN_INDIKATION_CODE = "SCHEMA202";
+
+    /**
+     * EN: Code for Tetanus Monokomponente.<br>
+     */
+    public static final String TETANUS_MONOKOMPONENTE_CODE = "SCHEMA083";
+
+    /**
+     * EN: Code for Tollwut.<br>
+     */
+    public static final String TOLLWUT_CODE = "SCHEMA246";
+
+    /**
+     * EN: Code for Tollwut Grundschema.<br>
+     */
+    public static final String TOLLWUT_GRUNDSCHEMA_CODE = "SCHEMA070";
+
+    /**
+     * EN: Code for Tollwut postexpositionelles Schema, Essen 4 Dosen.<br>
+     */
+    public static final String TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_ESSEN_4_DOSEN_CODE = "SCHEMA072";
+
+    /**
+     * EN: Code for Tollwut postexpositionelles Schema, Essen 5 Dosen.<br>
+     */
+    public static final String TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_ESSEN_5_DOSEN_CODE = "SCHEMA073";
+
+    /**
+     * EN: Code for Tollwut postexpositionelles Schema, mit Tollwut-Vorimpfung.<br>
+     */
+    public static final String TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_MIT_TOLLWUT_VORIMPFUNG_CODE = "SCHEMA075";
+
+    /**
+     * EN: Code for Tollwut postexpositionelles Schema, Zagreb.<br>
+     */
+    public static final String TOLLWUT_POSTEXPOSITIONELLES_SCHEMA_ZAGREB_CODE = "SCHEMA074";
+
+    /**
+     * EN: Code for Tollwut postexpositionell, Essen.<br>
+     */
+    public static final String TOLLWUT_POSTEXPOSITIONELL_ESSEN_CODE = "SCHEMA247";
+
+    /**
+     * EN: Code for Tollwut postexpositionell, mit Vorimpfung.<br>
+     */
+    public static final String TOLLWUT_POSTEXPOSITIONELL_MIT_VORIMPFUNG_CODE = "SCHEMA248";
+
+    /**
+     * EN: Code for Tollwut postexpositionell, Zagreb.<br>
+     */
+    public static final String TOLLWUT_POSTEXPOSITIONELL_ZAGREB_CODE = "SCHEMA249";
+
+    /**
+     * EN: Code for Tollwut Schnellschema.<br>
+     */
+    public static final String TOLLWUT_SCHNELLSCHEMA_CODE = "SCHEMA071";
+
+    /**
+     * EN: Code for Tollwut, Schnellschema.<br>
+     */
+    public static final String TOLLWUT_SCHNELLSCHEMA_CODE = "SCHEMA250";
+
+    /**
+     * EN: Code for Tollwut Schnellschema (WHO).<br>
+     */
+    public static final String TOLLWUT_SCHNELLSCHEMA_WHO_CODE = "SCHEMA123";
+
+    /**
+     * EN: Code for Tollwut, Schnellschema (WHO).<br>
+     */
+    public static final String TOLLWUT_SCHNELLSCHEMA_WHO_CODE = "SCHEMA251";
+
+    /**
+     * EN: Code for Tollwut Schnellschema (WHO), intradermal.<br>
+     */
+    public static final String TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL_CODE = "SCHEMA124";
+
+    /**
+     * EN: Code for Tollwut, Schnellschema (WHO) intradermal.<br>
+     */
+    public static final String TOLLWUT_SCHNELLSCHEMA_WHO_INTRADERMAL_CODE = "SCHEMA252";
+
+    /**
+     * EN: Code for Typhus.<br>
+     */
+    public static final String TYPHUS_CODE = "SCHEMA253";
+
+    /**
+     * EN: Code for Typhus Grundschema, Injektion.<br>
+     */
+    public static final String TYPHUS_GRUNDSCHEMA_INJEKTION_CODE = "SCHEMA068";
+
+    /**
+     * EN: Code for Typhus Grundschema, Oral.<br>
+     */
+    public static final String TYPHUS_GRUNDSCHEMA_ORAL_CODE = "SCHEMA069";
+
+    /**
+     * EN: Code for Varizellen.<br>
+     */
+    public static final String VARIZELLEN_CODE = "SCHEMA254";
+
+    /**
+     * EN: Code for Varizellen Grundschema, ab 1 Jahr.<br>
+     */
+    public static final String VARIZELLEN_GRUNDSCHEMA_AB_1_JAHR_CODE = "SCHEMA060";
+
+    /**
+     * EN: Code for Varizellen, Indikation.<br>
+     */
+    public static final String VARIZELLEN_INDIKATION_CODE = "SCHEMA255";
+
+    /**
+     * EN: Code for Varizellen Indikationsschema, Erstimpfung bis 1 Jahr.<br>
+     */
+    public static final String VARIZELLEN_INDIKATIONSSCHEMA_ERSTIMPFUNG_BIS_1_JAHR_CODE = "SCHEMA063";
+
+    /**
+     * EN: Code for Zoonotische Influenza (H5N8).<br>
+     */
+    public static final String ZOONOTISCHE_INFLUENZA_H5N8_CODE = "SCHEMA257";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.5";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-impfschema";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.183";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfImpfschema getEnum(@Nullable final String code) {
+        for (final EimpfImpfschema x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfImpfschema.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfImpfschema x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfImpfschema(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfstoffe.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfImpfstoffe.java
@@ -1,0 +1,3258 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-impfstoffe values
+ * <p>
+ * EN: No designation found.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.14<br>
+ * Effective date: 2025-10-06 16:44<br>
+ * Version: 2.26.1+20251007<br>
+ * Status: FINAL
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfImpfstoffe implements ValueSetEnumInterface {
+
+    /**
+     * EN: ABRYSVO IJLSG PLV+LSM DFL.<br>
+     */
+    ABRYSVO_IJLSG_PLV_LSM_DFL("5525687",
+                              "1.2.40.0.34.4.16.1",
+                              "ABRYSVO IJLSG PLV+LSM DFL",
+                              "ABRYSVO IJLSG PLV+LSM DFL",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: ACT-HIB TRSTAMP +LSM.<br>
+     */
+    ACT_HIB_TRSTAMP_LSM("1276939",
+                        "1.2.40.0.34.4.16.1",
+                        "ACT-HIB TRSTAMP +LSM",
+                        "ACT-HIB TRSTAMP +LSM",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: APEXXNAR IJSUS FSPR 0,5ML+ND.<br>
+     */
+    APEXXNAR_IJSUS_FSPR_0_5ML_ND("5508341",
+                                 "1.2.40.0.34.4.16.1",
+                                 "APEXXNAR IJSUS FSPR 0,5ML+ND",
+                                 "APEXXNAR IJSUS FSPR 0,5ML+ND",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: AREXVY PLV+SUSP IJSUS DFL.<br>
+     */
+    AREXVY_PLV_SUSP_IJSUS_DFL("5525380",
+                              "1.2.40.0.34.4.16.1",
+                              "AREXVY PLV+SUSP IJSUS DFL",
+                              "AREXVY PLV+SUSP IJSUS DFL",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: BEXSERO INJ.SUS FSPR.<br>
+     */
+    BEXSERO_INJ_SUS_FSPR("3920095",
+                         "1.2.40.0.34.4.16.1",
+                         "BEXSERO INJ.SUS FSPR",
+                         "BEXSERO INJ.SUS FSPR",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: BEYFORTUS FSP 100MG/1ML O.K.<br>
+     */
+    BEYFORTUS_FSP_100MG_1ML_O_K("5519126",
+                                "1.2.40.0.34.4.16.1",
+                                "BEYFORTUS FSP 100MG/1ML O.K",
+                                "BEYFORTUS FSP 100MG/1ML O.K",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: BEYFORTUS FSP 50MG/0,5ML O.K.<br>
+     */
+    BEYFORTUS_FSP_50MG_0_5ML_O_K("5519103",
+                                 "1.2.40.0.34.4.16.1",
+                                 "BEYFORTUS FSP 50MG/0,5ML O.K",
+                                 "BEYFORTUS FSP 50MG/0,5ML O.K",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: BOOSTRIX INJ FSPR 0,5ML.<br>
+     */
+    BOOSTRIX_INJ_FSPR_0_5ML("2420746",
+                            "1.2.40.0.34.4.16.1",
+                            "BOOSTRIX INJ FSPR 0,5ML",
+                            "BOOSTRIX INJ FSPR 0,5ML",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: BOOSTRIX POLIO FSPR 0,5ML.<br>
+     */
+    BOOSTRIX_POLIO_FSPR_0_5ML("2457324",
+                              "1.2.40.0.34.4.16.1",
+                              "BOOSTRIX POLIO FSPR 0,5ML",
+                              "BOOSTRIX POLIO FSPR 0,5ML",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: CAPVAXIVE INJ FSPR 0,5ML +1K.<br>
+     */
+    CAPVAXIVE_INJ_FSPR_0_5ML_1K("6057900",
+                                "1.2.40.0.34.4.16.1",
+                                "CAPVAXIVE INJ FSPR 0,5ML +1K",
+                                "CAPVAXIVE INJ FSPR 0,5ML +1K",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: CERVARIX FSPR 0,5ML.<br>
+     */
+    CERVARIX_FSPR_0_5ML("3513450",
+                        "1.2.40.0.34.4.16.1",
+                        "CERVARIX FSPR 0,5ML",
+                        "CERVARIX FSPR 0,5ML",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 BA1   10x6.<br>
+     */
+    COMIRNATY_COV19_BA1_10X6("5516837",
+                             "1.2.40.0.34.4.16.1",
+                             "COMIRNATY COV19 BA1   10x6",
+                             "COMIRNATY COV19 BA1   10x6",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 BA1  195x6.<br>
+     */
+    COMIRNATY_COV19_BA1_195X6("5516820",
+                              "1.2.40.0.34.4.16.1",
+                              "COMIRNATY COV19 BA1  195x6",
+                              "COMIRNATY COV19 BA1  195x6",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 BA4/5  10x6.<br>
+     */
+    COMIRNATY_COV19_BA4_5_10X6("5516866",
+                               "1.2.40.0.34.4.16.1",
+                               "COMIRNATY COV19 BA4/5  10x6",
+                               "COMIRNATY COV19 BA4/5  10x6",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 BA4/5 195x6.<br>
+     */
+    COMIRNATY_COV19_BA4_5_195X6("5516843",
+                                "1.2.40.0.34.4.16.1",
+                                "COMIRNATY COV19 BA4/5 195x6",
+                                "COMIRNATY COV19 BA4/5 195x6",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 INJ30  10x6.<br>
+     */
+    COMIRNATY_COV19_INJ30_10X6("5506359",
+                               "1.2.40.0.34.4.16.1",
+                               "COMIRNATY COV19 INJ30  10x6",
+                               "COMIRNATY COV19 INJ30  10x6",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 INJ30 195x6.<br>
+     */
+    COMIRNATY_COV19_INJ30_195X6("5506342",
+                                "1.2.40.0.34.4.16.1",
+                                "COMIRNATY COV19 INJ30 195x6",
+                                "COMIRNATY COV19 INJ30 195x6",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 KONZ10 10x10.<br>
+     */
+    COMIRNATY_COV19_KONZ10_10X10("5506448",
+                                 "1.2.40.0.34.4.16.1",
+                                 "COMIRNATY COV19 KONZ10 10x10",
+                                 "COMIRNATY COV19 KONZ10 10x10",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY COV19 KONZ30 195x6.<br>
+     */
+    COMIRNATY_COV19_KONZ30_195X6("4989539",
+                                 "1.2.40.0.34.4.16.1",
+                                 "COMIRNATY COV19 KONZ30 195x6",
+                                 "COMIRNATY COV19 KONZ30 195x6",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY JN.1 INJ10  10x6.<br>
+     */
+    COMIRNATY_JN_1_INJ10_10X6("5541924",
+                              "1.2.40.0.34.4.16.1",
+                              "COMIRNATY JN.1 INJ10  10x6",
+                              "COMIRNATY JN.1 INJ10  10x6",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY JN.1 INJ30  10x6.<br>
+     */
+    COMIRNATY_JN_1_INJ30_10X6("5541887",
+                              "1.2.40.0.34.4.16.1",
+                              "COMIRNATY JN.1 INJ30  10x6",
+                              "COMIRNATY JN.1 INJ30  10x6",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY JN.1 KO3   10x3.<br>
+     */
+    COMIRNATY_JN_1_KO3_10X3("5541947",
+                            "1.2.40.0.34.4.16.1",
+                            "COMIRNATY JN.1 KO3   10x3",
+                            "COMIRNATY JN.1 KO3   10x3",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY KO1,5/1,5  10x10.<br>
+     */
+    COMIRNATY_KO1_5_1_5_10X10("5516990",
+                              "1.2.40.0.34.4.16.1",
+                              "COMIRNATY KO1,5/1,5  10x10",
+                              "COMIRNATY KO1,5/1,5  10x10",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY KO3     10x10.<br>
+     */
+    COMIRNATY_KO3_10X10("5516984",
+                        "1.2.40.0.34.4.16.1",
+                        "COMIRNATY KO3     10x10",
+                        "COMIRNATY KO3     10x10",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY KO5/5 BA4/5 10x10.<br>
+     */
+    COMIRNATY_KO5_5_BA4_5_10X10("5517015",
+                                "1.2.40.0.34.4.16.1",
+                                "COMIRNATY KO5/5 BA4/5 10x10",
+                                "COMIRNATY KO5/5 BA4/5 10x10",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY KP.2 INJ10  10x6.<br>
+     */
+    COMIRNATY_KP_2_INJ10_10X6("6051323",
+                              "1.2.40.0.34.4.16.1",
+                              "COMIRNATY KP.2 INJ10  10x6",
+                              "COMIRNATY KP.2 INJ10  10x6",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY KP.2 INJ30  10x6.<br>
+     */
+    COMIRNATY_KP_2_INJ30_10X6("6051317",
+                              "1.2.40.0.34.4.16.1",
+                              "COMIRNATY KP.2 INJ30  10x6",
+                              "COMIRNATY KP.2 INJ30  10x6",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY KP.2 KO3   10x3.<br>
+     */
+    COMIRNATY_KP_2_KO3_10X3("6051346",
+                            "1.2.40.0.34.4.16.1",
+                            "COMIRNATY KP.2 KO3   10x3",
+                            "COMIRNATY KP.2 KO3   10x3",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY LP.8.1 INJ10 10x6.<br>
+     */
+    COMIRNATY_LP_8_1_INJ10_10X6("6062373",
+                                "1.2.40.0.34.4.16.1",
+                                "COMIRNATY LP.8.1 INJ10 10x6",
+                                "COMIRNATY LP.8.1 INJ10 10x6",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY LP.8.1 INJ30 10x6.<br>
+     */
+    COMIRNATY_LP_8_1_INJ30_10X6("6062367",
+                                "1.2.40.0.34.4.16.1",
+                                "COMIRNATY LP.8.1 INJ30 10x6",
+                                "COMIRNATY LP.8.1 INJ30 10x6",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY LP.8.1 KO3  10x3.<br>
+     */
+    COMIRNATY_LP_8_1_KO3_10X3("6062396",
+                              "1.2.40.0.34.4.16.1",
+                              "COMIRNATY LP.8.1 KO3  10x3",
+                              "COMIRNATY LP.8.1 KO3  10x3",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY XBB.1.5 INJ10 10x6.<br>
+     */
+    COMIRNATY_XBB_1_5_INJ10_10X6("5528243",
+                                 "1.2.40.0.34.4.16.1",
+                                 "COMIRNATY XBB.1.5 INJ10 10x6",
+                                 "COMIRNATY XBB.1.5 INJ10 10x6",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY XBB.1.5 INJ30 10x6.<br>
+     */
+    COMIRNATY_XBB_1_5_INJ30_10X6("5527775",
+                                 "1.2.40.0.34.4.16.1",
+                                 "COMIRNATY XBB.1.5 INJ30 10x6",
+                                 "COMIRNATY XBB.1.5 INJ30 10x6",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: COMIRNATY XBB.1.5 KO3 10x10.<br>
+     */
+    COMIRNATY_XBB_1_5_KO3_10X10("5528289",
+                                "1.2.40.0.34.4.16.1",
+                                "COMIRNATY XBB.1.5 KO3 10x10",
+                                "COMIRNATY XBB.1.5 KO3 10x10",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Abdala (Center for Genetic Engineering and Biotechnology).<br>
+     */
+    COVID_19_IMPFSTOFF_ABDALA_CENTER_FOR_GENETIC_ENGINEERING_AND_BIOTECHNOLOGY("AUSL_000016",
+                                                                               "1.2.40.0.34.4.16.1",
+                                                                               "COVID-19-Impfstoff Abdala (Center for Genetic Engineering and Biotechnology)",
+                                                                               "COVID-19-Impfstoff Abdala (Center for Genetic Engineering and Biotechnology)",
+                                                                               "TOTRANSLATE",
+                                                                               "TOTRANSLATE",
+                                                                               "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff AZD2816 (AstraZeneca AB).<br>
+     */
+    COVID_19_IMPFSTOFF_AZD2816_ASTRAZENECA_AB("AUSL_000029",
+                                              "1.2.40.0.34.4.16.1",
+                                              "COVID-19-Impfstoff AZD2816 (AstraZeneca AB)",
+                                              "COVID-19-Impfstoff AZD2816 (AstraZeneca AB)",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff BBIBP-CorV (Sinopharm).<br>
+     */
+    COVID_19_IMPFSTOFF_BBIBP_CORV_SINOPHARM("AUSL_000006",
+                                            "1.2.40.0.34.4.16.1",
+                                            "COVID-19-Impfstoff BBIBP-CorV (Sinopharm)",
+                                            "COVID-19-Impfstoff BBIBP-CorV (Sinopharm)",
+                                            "TOTRANSLATE",
+                                            "TOTRANSLATE",
+                                            "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Convidecia (CanSino Biologics).<br>
+     */
+    COVID_19_IMPFSTOFF_CONVIDECIA_CANSINO_BIOLOGICS("AUSL_000004",
+                                                    "1.2.40.0.34.4.16.1",
+                                                    "COVID-19-Impfstoff Convidecia (CanSino Biologics)",
+                                                    "COVID-19-Impfstoff Convidecia (CanSino Biologics)",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff CoronaVac (Sinovac Biotech).<br>
+     */
+    COVID_19_IMPFSTOFF_CORONAVAC_SINOVAC_BIOTECH("AUSL_000008",
+                                                 "1.2.40.0.34.4.16.1",
+                                                 "COVID-19-Impfstoff CoronaVac (Sinovac Biotech)",
+                                                 "COVID-19-Impfstoff CoronaVac (Sinovac Biotech)",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Covaxin (Bharat Biotech).<br>
+     */
+    COVID_19_IMPFSTOFF_COVAXIN_BHARAT_BIOTECH("AUSL_000009",
+                                              "1.2.40.0.34.4.16.1",
+                                              "COVID-19-Impfstoff Covaxin (Bharat Biotech)",
+                                              "COVID-19-Impfstoff Covaxin (Bharat Biotech)",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Covid-19 (recombinant) (Fiocruz).<br>
+     */
+    COVID_19_IMPFSTOFF_COVID_19_RECOMBINANT_FIOCRUZ("AUSL_000011",
+                                                    "1.2.40.0.34.4.16.1",
+                                                    "COVID-19-Impfstoff Covid-19 (recombinant) (Fiocruz)",
+                                                    "COVID-19-Impfstoff Covid-19 (recombinant) (Fiocruz)",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Covifenz (Medicago Inc.).<br>
+     */
+    COVID_19_IMPFSTOFF_COVIFENZ_MEDICAGO_INC("AUSL_000028",
+                                             "1.2.40.0.34.4.16.1",
+                                             "COVID-19-Impfstoff Covifenz (Medicago Inc.)",
+                                             "COVID-19-Impfstoff Covifenz (Medicago Inc.)",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Covishield (Serum Institute of India).<br>
+     */
+    COVID_19_IMPFSTOFF_COVISHIELD_SERUM_INSTITUTE_OF_INDIA("AUSL_000010",
+                                                           "1.2.40.0.34.4.16.1",
+                                                           "COVID-19-Impfstoff Covishield (Serum Institute of India)",
+                                                           "COVID-19-Impfstoff Covishield (Serum Institute of India)",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE",
+                                                           "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff CoviVac (Chumakov-Federal-Scientific-Center).<br>
+     */
+    COVID_19_IMPFSTOFF_COVIVAC_CHUMAKOV_FEDERAL_SCIENTIFIC_CENTER("AUSL_000013",
+                                                                  "1.2.40.0.34.4.16.1",
+                                                                  "COVID-19-Impfstoff CoviVac (Chumakov-Federal-Scientific-Center)",
+                                                                  "COVID-19-Impfstoff CoviVac (Chumakov-Federal-Scientific-Center)",
+                                                                  "TOTRANSLATE",
+                                                                  "TOTRANSLATE",
+                                                                  "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Covovax (Serum Institute Of India Private Limited).<br>
+     */
+    COVID_19_IMPFSTOFF_COVOVAX_SERUM_INSTITUTE_OF_INDIA_PRIVATE_LIMITED("AUSL_000019",
+                                                                        "1.2.40.0.34.4.16.1",
+                                                                        "COVID-19-Impfstoff Covovax (Serum Institute Of India Private Limited)",
+                                                                        "COVID-19-Impfstoff Covovax (Serum Institute Of India Private Limited)",
+                                                                        "TOTRANSLATE",
+                                                                        "TOTRANSLATE",
+                                                                        "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff CVnCoV (CureVac).<br>
+     */
+    COVID_19_IMPFSTOFF_CVNCOV_CUREVAC("AUSL_000001",
+                                      "1.2.40.0.34.4.16.1",
+                                      "COVID-19-Impfstoff CVnCoV (CureVac)",
+                                      "COVID-19-Impfstoff CVnCoV (CureVac)",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff EpiVacCorona-N (Vector Institute).<br>
+     */
+    COVID_19_IMPFSTOFF_EPIVACCORONA_N_VECTOR_INSTITUTE("AUSL_000022",
+                                                       "1.2.40.0.34.4.16.1",
+                                                       "COVID-19-Impfstoff EpiVacCorona-N (Vector Institute)",
+                                                       "COVID-19-Impfstoff EpiVacCorona-N (Vector Institute)",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE",
+                                                       "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff EpiVacCorona (Vektor-Institut).<br>
+     */
+    COVID_19_IMPFSTOFF_EPIVACCORONA_VEKTOR_INSTITUT("AUSL_000005",
+                                                    "1.2.40.0.34.4.16.1",
+                                                    "COVID-19-Impfstoff EpiVacCorona (Vektor-Institut)",
+                                                    "COVID-19-Impfstoff EpiVacCorona (Vektor-Institut)",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Hayat-Vax (Gulf Pharmaceutical Industries).<br>
+     */
+    COVID_19_IMPFSTOFF_HAYAT_VAX_GULF_PHARMACEUTICAL_INDUSTRIES("AUSL_000015",
+                                                                "1.2.40.0.34.4.16.1",
+                                                                "COVID-19-Impfstoff Hayat-Vax (Gulf Pharmaceutical Industries)",
+                                                                "COVID-19-Impfstoff Hayat-Vax (Gulf Pharmaceutical Industries)",
+                                                                "TOTRANSLATE",
+                                                                "TOTRANSLATE",
+                                                                "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Inactivated-SARS-CoV-2-Vero-Cell.<br>
+     */
+    COVID_19_IMPFSTOFF_INACTIVATED_SARS_COV_2_VERO_CELL("AUSL_000007",
+                                                        "1.2.40.0.34.4.16.1",
+                                                        "COVID-19-Impfstoff Inactivated-SARS-CoV-2-Vero-Cell",
+                                                        "COVID-19-Impfstoff Inactivated-SARS-CoV-2-Vero-Cell",
+                                                        "TOTRANSLATE",
+                                                        "TOTRANSLATE",
+                                                        "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff MVC COVID-19 vaccine (Medigen Vaccine Biologics Corporation).<br>
+     */
+    COVID_19_IMPFSTOFF_MVC_COVID_19_VACCINE_MEDIGEN_VACCINE_BIOLOGICS_CORPORATION("AUSL_000018",
+                                                                                  "1.2.40.0.34.4.16.1",
+                                                                                  "COVID-19-Impfstoff MVC COVID-19 vaccine (Medigen Vaccine Biologics Corporation)",
+                                                                                  "COVID-19-Impfstoff MVC COVID-19 vaccine (Medigen Vaccine Biologics Corporation)",
+                                                                                  "TOTRANSLATE",
+                                                                                  "TOTRANSLATE",
+                                                                                  "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff NVSI-06-08 (National Vaccine and Serum Institute, China).<br>
+     */
+    COVID_19_IMPFSTOFF_NVSI_06_08_NATIONAL_VACCINE_AND_SERUM_INSTITUTE_CHINA("AUSL_000025",
+                                                                             "1.2.40.0.34.4.16.1",
+                                                                             "COVID-19-Impfstoff NVSI-06-08 (National Vaccine and Serum Institute, China)",
+                                                                             "COVID-19-Impfstoff NVSI-06-08 (National Vaccine and Serum Institute, China)",
+                                                                             "TOTRANSLATE",
+                                                                             "TOTRANSLATE",
+                                                                             "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff NVX-CoV2373 (Novavax).<br>
+     */
+    COVID_19_IMPFSTOFF_NVX_COV2373_NOVAVAX("AUSL_000002",
+                                           "1.2.40.0.34.4.16.1",
+                                           "COVID-19-Impfstoff NVX-CoV2373 (Novavax)",
+                                           "COVID-19-Impfstoff NVX-CoV2373 (Novavax)",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff R-COVI (R-Pharm CJSC).<br>
+     */
+    COVID_19_IMPFSTOFF_R_COVI_R_PHARM_CJSC("AUSL_000012",
+                                           "1.2.40.0.34.4.16.1",
+                                           "COVID-19-Impfstoff R-COVI (R-Pharm CJSC)",
+                                           "COVID-19-Impfstoff R-COVI (R-Pharm CJSC)",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff SCTV01C (Sinocelltech Ltd.).<br>
+     */
+    COVID_19_IMPFSTOFF_SCTV01C_SINOCELLTECH_LTD("AUSL_000027",
+                                                "1.2.40.0.34.4.16.1",
+                                                "COVID-19-Impfstoff SCTV01C (Sinocelltech Ltd.)",
+                                                "COVID-19-Impfstoff SCTV01C (Sinocelltech Ltd.)",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Soberana 02 (Finlay-Institute).<br>
+     */
+    COVID_19_IMPFSTOFF_SOBERANA_02_FINLAY_INSTITUTE("AUSL_000030",
+                                                    "1.2.40.0.34.4.16.1",
+                                                    "COVID-19-Impfstoff Soberana 02 (Finlay-Institute)",
+                                                    "COVID-19-Impfstoff Soberana 02 (Finlay-Institute)",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Soberana Plus (Finlay-Institute).<br>
+     */
+    COVID_19_IMPFSTOFF_SOBERANA_PLUS_FINLAY_INSTITUTE("AUSL_000031",
+                                                      "1.2.40.0.34.4.16.1",
+                                                      "COVID-19-Impfstoff Soberana Plus (Finlay-Institute)",
+                                                      "COVID-19-Impfstoff Soberana Plus (Finlay-Institute)",
+                                                      "TOTRANSLATE",
+                                                      "TOTRANSLATE",
+                                                      "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Sputnik-Light (Gamaleya).<br>
+     */
+    COVID_19_IMPFSTOFF_SPUTNIK_LIGHT_GAMALEYA("AUSL_000014",
+                                              "1.2.40.0.34.4.16.1",
+                                              "COVID-19-Impfstoff Sputnik-Light (Gamaleya)",
+                                              "COVID-19-Impfstoff Sputnik-Light (Gamaleya)",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Sputnik-M (Gamaleya Research Institute).<br>
+     */
+    COVID_19_IMPFSTOFF_SPUTNIK_M_GAMALEYA_RESEARCH_INSTITUTE("AUSL_000023",
+                                                             "1.2.40.0.34.4.16.1",
+                                                             "COVID-19-Impfstoff Sputnik-M (Gamaleya Research Institute)",
+                                                             "COVID-19-Impfstoff Sputnik-M (Gamaleya Research Institute)",
+                                                             "TOTRANSLATE",
+                                                             "TOTRANSLATE",
+                                                             "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Sputnik-V (Gamaleya).<br>
+     */
+    COVID_19_IMPFSTOFF_SPUTNIK_V_GAMALEYA("AUSL_000003",
+                                          "1.2.40.0.34.4.16.1",
+                                          "COVID-19-Impfstoff Sputnik-V (Gamaleya)",
+                                          "COVID-19-Impfstoff Sputnik-V (Gamaleya)",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Vacina adsorvida covid-19 (inativada) (Instituto Butantan).<br>
+     */
+    COVID_19_IMPFSTOFF_VACINA_ADSORVIDA_COVID_19_INATIVADA_INSTITUTO_BUTANTAN("AUSL_000024",
+                                                                              "1.2.40.0.34.4.16.1",
+                                                                              "COVID-19-Impfstoff Vacina adsorvida covid-19 (inativada) (Instituto Butantan)",
+                                                                              "COVID-19-Impfstoff Vacina adsorvida covid-19 (inativada) (Instituto Butantan)",
+                                                                              "TOTRANSLATE",
+                                                                              "TOTRANSLATE",
+                                                                              "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff Vidprevtyn (Sanofi Pasteur).<br>
+     */
+    COVID_19_IMPFSTOFF_VIDPREVTYN_SANOFI_PASTEUR("AUSL_000020",
+                                                 "1.2.40.0.34.4.16.1",
+                                                 "COVID-19-Impfstoff Vidprevtyn (Sanofi Pasteur)",
+                                                 "COVID-19-Impfstoff Vidprevtyn (Sanofi Pasteur)",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff VLA2001 (Valneva France).<br>
+     */
+    COVID_19_IMPFSTOFF_VLA2001_VALNEVA_FRANCE("AUSL_000021",
+                                              "1.2.40.0.34.4.16.1",
+                                              "COVID-19-Impfstoff VLA2001 (Valneva France)",
+                                              "COVID-19-Impfstoff VLA2001 (Valneva France)",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff WIBP-CorV (Sinopharm - Wuhan Institute of Biological Products).<br>
+     */
+    COVID_19_IMPFSTOFF_WIBP_CORV_SINOPHARM_WUHAN_INSTITUTE_OF_BIOLOGICAL_PRODUCTS("AUSL_000017",
+                                                                                  "1.2.40.0.34.4.16.1",
+                                                                                  "COVID-19-Impfstoff WIBP-CorV (Sinopharm - Wuhan Institute of Biological Products)",
+                                                                                  "COVID-19-Impfstoff WIBP-CorV (Sinopharm - Wuhan Institute of Biological Products)",
+                                                                                  "TOTRANSLATE",
+                                                                                  "TOTRANSLATE",
+                                                                                  "TOTRANSLATE"),
+    /**
+     * EN: COVID-19-Impfstoff YS-SC2-010 (Yisheng Biopharma).<br>
+     */
+    COVID_19_IMPFSTOFF_YS_SC2_010_YISHENG_BIOPHARMA("AUSL_000026",
+                                                    "1.2.40.0.34.4.16.1",
+                                                    "COVID-19-Impfstoff YS-SC2-010 (Yisheng Biopharma)",
+                                                    "COVID-19-Impfstoff YS-SC2-010 (Yisheng Biopharma)",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE",
+                                                    "TOTRANSLATE"),
+    /**
+     * EN: DTAP BOOSTER FSPR 0,5ML.<br>
+     */
+    DTAP_BOOSTER_FSPR_0_5ML("5543308",
+                            "1.2.40.0.34.4.16.1",
+                            "DTAP BOOSTER FSPR 0,5ML",
+                            "DTAP BOOSTER FSPR 0,5ML",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: DT-REDUCT MER FSPR 0,5ML.<br>
+     */
+    DT_REDUCT_MER_FSPR_0_5ML("1290520",
+                             "1.2.40.0.34.4.16.1",
+                             "DT-REDUCT MER FSPR 0,5ML",
+                             "DT-REDUCT MER FSPR 0,5ML",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: DUKORAL SUSP+BRGRAN 2X1DOSIS.<br>
+     */
+    DUKORAL_SUSP_BRGRAN_2X1DOSIS("2465140",
+                                 "1.2.40.0.34.4.16.1",
+                                 "DUKORAL SUSP+BRGRAN 2X1DOSIS",
+                                 "DUKORAL SUSP+BRGRAN 2X1DOSIS",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: EFLUELDA TETRA FSP 0,7ML O.K.<br>
+     */
+    EFLUELDA_TETRA_FSP_0_7ML_O_K("4989918",
+                                 "1.2.40.0.34.4.16.1",
+                                 "EFLUELDA TETRA FSP 0,7ML O.K",
+                                 "EFLUELDA TETRA FSP 0,7ML O.K",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: EFLUELDA TRIVA FSP 0,5ML O.K.<br>
+     */
+    EFLUELDA_TRIVA_FSP_0_5ML_O_K("6050128",
+                                 "1.2.40.0.34.4.16.1",
+                                 "EFLUELDA TRIVA FSP 0,5ML O.K",
+                                 "EFLUELDA TRIVA FSP 0,5ML O.K",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: ENCEPUR FSPR 0,25ML KIND.<br>
+     */
+    ENCEPUR_FSPR_0_25ML_KIND("2427872",
+                             "1.2.40.0.34.4.16.1",
+                             "ENCEPUR FSPR 0,25ML KIND",
+                             "ENCEPUR FSPR 0,25ML KIND",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: ENCEPUR FSPR 0,25ML KIND BN.<br>
+     */
+    ENCEPUR_FSPR_0_25ML_KIND_BN("4977720",
+                                "1.2.40.0.34.4.16.1",
+                                "ENCEPUR FSPR 0,25ML KIND BN",
+                                "ENCEPUR FSPR 0,25ML KIND BN",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: ENCEPUR FSPR 0,25ML KIND +ND.<br>
+     */
+    ENCEPUR_FSPR_0_25ML_KIND_ND("4977134",
+                                "1.2.40.0.34.4.16.1",
+                                "ENCEPUR FSPR 0,25ML KIND +ND",
+                                "ENCEPUR FSPR 0,25ML KIND +ND",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: ENCEPUR FSPR 0,5ML.<br>
+     */
+    ENCEPUR_FSPR_0_5ML("2246975",
+                       "1.2.40.0.34.4.16.1",
+                       "ENCEPUR FSPR 0,5ML",
+                       "ENCEPUR FSPR 0,5ML",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: ENCEPUR FSPR 0,5ML BN.<br>
+     */
+    ENCEPUR_FSPR_0_5ML_BN("4977714",
+                          "1.2.40.0.34.4.16.1",
+                          "ENCEPUR FSPR 0,5ML BN",
+                          "ENCEPUR FSPR 0,5ML BN",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: ENCEPUR FSPR 0,5ML +ND.<br>
+     */
+    ENCEPUR_FSPR_0_5ML_ND("4977140",
+                          "1.2.40.0.34.4.16.1",
+                          "ENCEPUR FSPR 0,5ML +ND",
+                          "ENCEPUR FSPR 0,5ML +ND",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: ENGERIX-B FSPR 10MCG/0,5ML.<br>
+     */
+    ENGERIX_B_FSPR_10MCG_0_5ML("1292200",
+                               "1.2.40.0.34.4.16.1",
+                               "ENGERIX-B FSPR 10MCG/0,5ML",
+                               "ENGERIX-B FSPR 10MCG/0,5ML",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: ENGERIX-B FSPR 20MCG/1ML.<br>
+     */
+    ENGERIX_B_FSPR_20MCG_1ML("1364721",
+                             "1.2.40.0.34.4.16.1",
+                             "ENGERIX-B FSPR 20MCG/1ML",
+                             "ENGERIX-B FSPR 20MCG/1ML",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: FLUAD FSPR 0,5ML.<br>
+     */
+    FLUAD_FSPR_0_5ML("1349762",
+                     "1.2.40.0.34.4.16.1",
+                     "FLUAD FSPR 0,5ML",
+                     "FLUAD FSPR 0,5ML",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: FLUAD IJSUS FSPR 0,5ML.<br>
+     */
+    FLUAD_IJSUS_FSPR_0_5ML("6054586",
+                           "1.2.40.0.34.4.16.1",
+                           "FLUAD IJSUS FSPR 0,5ML",
+                           "FLUAD IJSUS FSPR 0,5ML",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: FLUAD TETRA FSPR 0,5ML.<br>
+     */
+    FLUAD_TETRA_FSPR_0_5ML("5509702",
+                           "1.2.40.0.34.4.16.1",
+                           "FLUAD TETRA FSPR 0,5ML",
+                           "FLUAD TETRA FSPR 0,5ML",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: FLUAD TETRA FSPR+ND 0,5ML.<br>
+     */
+    FLUAD_TETRA_FSPR_ND_0_5ML("4990123",
+                              "1.2.40.0.34.4.16.1",
+                              "FLUAD TETRA FSPR+ND 0,5ML",
+                              "FLUAD TETRA FSPR+ND 0,5ML",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: FLUARIX INJ.SUS FSPR O.NADEL.<br>
+     */
+    FLUARIX_INJ_SUS_FSPR_O_NADEL("3927186",
+                                 "1.2.40.0.34.4.16.1",
+                                 "FLUARIX INJ.SUS FSPR O.NADEL",
+                                 "FLUARIX INJ.SUS FSPR O.NADEL",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: FLUARIX TETRA FSPR +2ND.<br>
+     */
+    FLUARIX_TETRA_FSPR_2ND("4205785",
+                           "1.2.40.0.34.4.16.1",
+                           "FLUARIX TETRA FSPR +2ND",
+                           "FLUARIX TETRA FSPR +2ND",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: FLUCELVAX IJSUS FSPR 0,5ML.<br>
+     */
+    FLUCELVAX_IJSUS_FSPR_0_5ML("6054592",
+                               "1.2.40.0.34.4.16.1",
+                               "FLUCELVAX IJSUS FSPR 0,5ML",
+                               "FLUCELVAX IJSUS FSPR 0,5ML",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: FLUCELVAX TETRA FSPR 0,5ML.<br>
+     */
+    FLUCELVAX_TETRA_FSPR_0_5ML("4963675",
+                               "1.2.40.0.34.4.16.1",
+                               "FLUCELVAX TETRA FSPR 0,5ML",
+                               "FLUCELVAX TETRA FSPR 0,5ML",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: FLUCELVAX TETRA IJSUS FSPR.<br>
+     */
+    FLUCELVAX_TETRA_IJSUS_FSPR("4963681",
+                               "1.2.40.0.34.4.16.1",
+                               "FLUCELVAX TETRA IJSUS FSPR",
+                               "FLUCELVAX TETRA IJSUS FSPR",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: FLUENZ NA-SPRAY.<br>
+     */
+    FLUENZ_NA_SPRAY("5536975",
+                    "1.2.40.0.34.4.16.1",
+                    "FLUENZ NA-SPRAY",
+                    "FLUENZ NA-SPRAY",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: FLUENZ TETRA NA-SPRAY.<br>
+     */
+    FLUENZ_TETRA_NA_SPRAY("4202025",
+                          "1.2.40.0.34.4.16.1",
+                          "FLUENZ TETRA NA-SPRAY",
+                          "FLUENZ TETRA NA-SPRAY",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: FLUVACCINOL INJ-SUS FSPR.<br>
+     */
+    FLUVACCINOL_INJ_SUS_FSPR("3528434",
+                             "1.2.40.0.34.4.16.1",
+                             "FLUVACCINOL INJ-SUS FSPR",
+                             "FLUVACCINOL INJ-SUS FSPR",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: FLUZONE/EFLUELDA 10St.<br>
+     */
+    FLUZONE_EFLUELDA_10ST("AWEG_000001",
+                          "1.2.40.0.34.4.16.1",
+                          "FLUZONE/EFLUELDA 10St",
+                          "FLUZONE/EFLUELDA 10St",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,25ML.<br>
+     */
+    FSME_IMMUN_FSPR_0_25ML("3925655",
+                           "1.2.40.0.34.4.16.1",
+                           "FSME-IMMUN FSPR 0,25ML",
+                           "FSME-IMMUN FSPR 0,25ML",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,25ML NAD B.<br>
+     */
+    FSME_IMMUN_FSPR_0_25ML_NAD_B("3925649",
+                                 "1.2.40.0.34.4.16.1",
+                                 "FSME-IMMUN FSPR 0,25ML NAD B",
+                                 "FSME-IMMUN FSPR 0,25ML NAD B",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,25ML NAD F.<br>
+     */
+    FSME_IMMUN_FSPR_0_25ML_NAD_F("2427180",
+                                 "1.2.40.0.34.4.16.1",
+                                 "FSME-IMMUN FSPR 0,25ML NAD F",
+                                 "FSME-IMMUN FSPR 0,25ML NAD F",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,25ML+S.NAD.<br>
+     */
+    FSME_IMMUN_FSPR_0_25ML_S_NAD("4209702",
+                                 "1.2.40.0.34.4.16.1",
+                                 "FSME-IMMUN FSPR 0,25ML+S.NAD",
+                                 "FSME-IMMUN FSPR 0,25ML+S.NAD",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,5ML.<br>
+     */
+    FSME_IMMUN_FSPR_0_5ML("3932454",
+                          "1.2.40.0.34.4.16.1",
+                          "FSME-IMMUN FSPR 0,5ML",
+                          "FSME-IMMUN FSPR 0,5ML",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,5ML NAD B.<br>
+     */
+    FSME_IMMUN_FSPR_0_5ML_NAD_B("3932448",
+                                "1.2.40.0.34.4.16.1",
+                                "FSME-IMMUN FSPR 0,5ML NAD B",
+                                "FSME-IMMUN FSPR 0,5ML NAD B",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,5ML NAD F.<br>
+     */
+    FSME_IMMUN_FSPR_0_5ML_NAD_F("0514986",
+                                "1.2.40.0.34.4.16.1",
+                                "FSME-IMMUN FSPR 0,5ML NAD F",
+                                "FSME-IMMUN FSPR 0,5ML NAD F",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: FSME-IMMUN FSPR 0,5ML+S.NAD.<br>
+     */
+    FSME_IMMUN_FSPR_0_5ML_S_NAD("4209694",
+                                "1.2.40.0.34.4.16.1",
+                                "FSME-IMMUN FSPR 0,5ML+S.NAD",
+                                "FSME-IMMUN FSPR 0,5ML+S.NAD",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: GARDASIL 9 FSPR +2KAN.<br>
+     */
+    GARDASIL_9_FSPR_2KAN("4224707",
+                         "1.2.40.0.34.4.16.1",
+                         "GARDASIL 9 FSPR +2KAN",
+                         "GARDASIL 9 FSPR +2KAN",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: GARDASIL SPR +2KAN.<br>
+     */
+    GARDASIL_SPR_2KAN("3514171",
+                      "1.2.40.0.34.4.16.1",
+                      "GARDASIL SPR +2KAN",
+                      "GARDASIL SPR +2KAN",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: HAVRIX FSPR 1440 ERW.<br>
+     */
+    HAVRIX_FSPR_1440_ERW("1301057",
+                         "1.2.40.0.34.4.16.1",
+                         "HAVRIX FSPR 1440 ERW",
+                         "HAVRIX FSPR 1440 ERW",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: HAVRIX FSPR 720 JUNIOR.<br>
+     */
+    HAVRIX_FSPR_720_JUNIOR("1315496",
+                           "1.2.40.0.34.4.16.1",
+                           "HAVRIX FSPR 720 JUNIOR",
+                           "HAVRIX FSPR 720 JUNIOR",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: HBVAXPRO IJSUS FLA 40MCG.<br>
+     */
+    HBVAXPRO_IJSUS_FLA_40MCG("1350268",
+                             "1.2.40.0.34.4.16.1",
+                             "HBVAXPRO IJSUS FLA 40MCG",
+                             "HBVAXPRO IJSUS FLA 40MCG",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: HBVAXPRO IJSUS FSP 10MCG 2KN.<br>
+     */
+    HBVAXPRO_IJSUS_FSP_10MCG_2KN("3519599",
+                                 "1.2.40.0.34.4.16.1",
+                                 "HBVAXPRO IJSUS FSP 10MCG 2KN",
+                                 "HBVAXPRO IJSUS FSP 10MCG 2KN",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: HBVAXPRO IJSUS FSP 5MCG 2KN.<br>
+     */
+    HBVAXPRO_IJSUS_FSP_5MCG_2KN("2467765",
+                                "1.2.40.0.34.4.16.1",
+                                "HBVAXPRO IJSUS FSP 5MCG 2KN",
+                                "HBVAXPRO IJSUS FSP 5MCG 2KN",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: HEPATYRIX IJSUS FSPR.<br>
+     */
+    HEPATYRIX_IJSUS_FSPR("2442831",
+                         "1.2.40.0.34.4.16.1",
+                         "HEPATYRIX IJSUS FSPR",
+                         "HEPATYRIX IJSUS FSPR",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: HEXYON IJSUS FSPR +2 KAN.<br>
+     */
+    HEXYON_IJSUS_FSPR_2_KAN("3928168",
+                            "1.2.40.0.34.4.16.1",
+                            "HEXYON IJSUS FSPR +2 KAN",
+                            "HEXYON IJSUS FSPR +2 KAN",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: IAA FLUAD TETRA FSPR 0,5ML.<br>
+     */
+    IAA_FLUAD_TETRA_FSPR_0_5ML("5801437",
+                               "1.2.40.0.34.4.16.1",
+                               "IAA FLUAD TETRA FSPR 0,5ML",
+                               "IAA FLUAD TETRA FSPR 0,5ML",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: IAA FLUARIX TETRA FSPR +2ND.<br>
+     */
+    IAA_FLUARIX_TETRA_FSPR_2ND("5801495",
+                               "1.2.40.0.34.4.16.1",
+                               "IAA FLUARIX TETRA FSPR +2ND",
+                               "IAA FLUARIX TETRA FSPR +2ND",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: IAA FLUENZ TETRA NA-SPRAY.<br>
+     */
+    IAA_FLUENZ_TETRA_NA_SPRAY("5801354",
+                              "1.2.40.0.34.4.16.1",
+                              "IAA FLUENZ TETRA NA-SPRAY",
+                              "IAA FLUENZ TETRA NA-SPRAY",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: IAA VAXIGRIP TETRA FSPR O.K.<br>
+     */
+    IAA_VAXIGRIP_TETRA_FSPR_O_K("5801472",
+                                "1.2.40.0.34.4.16.1",
+                                "IAA VAXIGRIP TETRA FSPR O.K",
+                                "IAA VAXIGRIP TETRA FSPR O.K",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: IMVANEX 20ST.<br>
+     */
+    IMVANEX_20ST("AWEG_000005",
+                 "1.2.40.0.34.4.16.1",
+                 "IMVANEX 20ST",
+                 "IMVANEX 20ST",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: INFANRIX HEXA PLV INJS FSPR.<br>
+     */
+    INFANRIX_HEXA_PLV_INJS_FSPR("2479314",
+                                "1.2.40.0.34.4.16.1",
+                                "INFANRIX HEXA PLV INJS FSPR",
+                                "INFANRIX HEXA PLV INJS FSPR",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: INFLUSPLIT TETRA 1ST.<br>
+     */
+    INFLUSPLIT_TETRA_1ST("AWEG_000003",
+                         "1.2.40.0.34.4.16.1",
+                         "INFLUSPLIT TETRA 1ST",
+                         "INFLUSPLIT TETRA 1ST",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: INFLUVAC FSPR 0,5ML.<br>
+     */
+    INFLUVAC_FSPR_0_5ML("1258120",
+                        "1.2.40.0.34.4.16.1",
+                        "INFLUVAC FSPR 0,5ML",
+                        "INFLUVAC FSPR 0,5ML",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: INFLUVAC FSPR 0,5ML O.KANUEL.<br>
+     */
+    INFLUVAC_FSPR_0_5ML_O_KANUEL("1265597",
+                                 "1.2.40.0.34.4.16.1",
+                                 "INFLUVAC FSPR 0,5ML O.KANUEL",
+                                 "INFLUVAC FSPR 0,5ML O.KANUEL",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: INFLUVAC TETRA FSPR0,5ML M.K.<br>
+     */
+    INFLUVAC_TETRA_FSPR0_5ML_M_K("4482993",
+                                 "1.2.40.0.34.4.16.1",
+                                 "INFLUVAC TETRA FSPR0,5ML M.K",
+                                 "INFLUVAC TETRA FSPR0,5ML M.K",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: INFLUVAC TETRA FSPR0,5ML O.K.<br>
+     */
+    INFLUVAC_TETRA_FSPR0_5ML_O_K("5534491",
+                                 "1.2.40.0.34.4.16.1",
+                                 "INFLUVAC TETRA FSPR0,5ML O.K",
+                                 "INFLUVAC TETRA FSPR0,5ML O.K",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: INFLUVAC TRI FSPR 0,5ML O.K.<br>
+     */
+    INFLUVAC_TRI_FSPR_0_5ML_O_K("6052771",
+                                "1.2.40.0.34.4.16.1",
+                                "INFLUVAC TRI FSPR 0,5ML O.K.",
+                                "INFLUVAC TRI FSPR 0,5ML O.K.",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: INTANZA 15MCG FSPR.<br>
+     */
+    INTANZA_15MCG_FSPR("3539969",
+                       "1.2.40.0.34.4.16.1",
+                       "INTANZA 15MCG FSPR",
+                       "INTANZA 15MCG FSPR",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: INTANZA 9MCG FSPR.<br>
+     */
+    INTANZA_9MCG_FSPR("3761739",
+                      "1.2.40.0.34.4.16.1",
+                      "INTANZA 9MCG FSPR",
+                      "INTANZA 9MCG FSPR",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: IXCHIQ INJ PLV+LSM FSP 0,5ML.<br>
+     */
+    IXCHIQ_INJ_PLV_LSM_FSP_0_5ML("5534284",
+                                 "1.2.40.0.34.4.16.1",
+                                 "IXCHIQ INJ PLV+LSM FSP 0,5ML",
+                                 "IXCHIQ INJ PLV+LSM FSP 0,5ML",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: IXIARO FSPR.<br>
+     */
+    IXIARO_FSPR("3537551",
+                "1.2.40.0.34.4.16.1",
+                "IXIARO FSPR",
+                "IXIARO FSPR",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: JCOVDEN COV19      10x5.<br>
+     */
+    JCOVDEN_COV19_10X5("4991720",
+                       "1.2.40.0.34.4.16.1",
+                       "JCOVDEN COV19      10x5",
+                       "JCOVDEN COV19      10x5",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: JCOVDEN COV19      20x5.<br>
+     */
+    JCOVDEN_COV19_20X5("5502522",
+                       "1.2.40.0.34.4.16.1",
+                       "JCOVDEN COV19      20x5",
+                       "JCOVDEN COV19      20x5",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: JYNNEOS 20ST.<br>
+     */
+    JYNNEOS_20ST("AWEG_000004",
+                 "1.2.40.0.34.4.16.1",
+                 "JYNNEOS 20ST",
+                 "JYNNEOS 20ST",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: MENJUGATE INJ FSPR 10MCG.<br>
+     */
+    MENJUGATE_INJ_FSPR_10MCG("4453106",
+                             "1.2.40.0.34.4.16.1",
+                             "MENJUGATE INJ FSPR 10MCG",
+                             "MENJUGATE INJ FSPR 10MCG",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: MENJUGATE PLV +LSM FSPR.<br>
+     */
+    MENJUGATE_PLV_LSM_FSPR("3521662",
+                           "1.2.40.0.34.4.16.1",
+                           "MENJUGATE PLV +LSM FSPR",
+                           "MENJUGATE PLV +LSM FSPR",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: MENVEO PLV+LSM DFL.<br>
+     */
+    MENVEO_PLV_LSM_DFL("3782291",
+                       "1.2.40.0.34.4.16.1",
+                       "MENVEO PLV+LSM DFL",
+                       "MENVEO PLV+LSM DFL",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: MMRVAXPRO PLV+LSM FSPR +2K.<br>
+     */
+    MMRVAXPRO_PLV_LSM_FSPR_2K("3511764",
+                              "1.2.40.0.34.4.16.1",
+                              "MMRVAXPRO PLV+LSM FSPR +2K",
+                              "MMRVAXPRO PLV+LSM FSPR +2K",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: MODERNA/SPIKEVAX COV19 10x10.<br>
+     */
+    MODERNA_SPIKEVAX_COV19_10X10("5426873",
+                                 "1.2.40.0.34.4.16.1",
+                                 "MODERNA/SPIKEVAX COV19 10x10",
+                                 "MODERNA/SPIKEVAX COV19 10x10",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: MODERNA/SPIKEVAX COV19 1x10.<br>
+     */
+    MODERNA_SPIKEVAX_COV19_1X10("5426867",
+                                "1.2.40.0.34.4.16.1",
+                                "MODERNA/SPIKEVAX COV19 1x10",
+                                "MODERNA/SPIKEVAX COV19 1x10",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: NEISVAC-C FSPR 2 NADEL 0,5ML.<br>
+     */
+    NEISVAC_C_FSPR_2_NADEL_0_5ML("3532424",
+                                 "1.2.40.0.34.4.16.1",
+                                 "NEISVAC-C FSPR 2 NADEL 0,5ML",
+                                 "NEISVAC-C FSPR 2 NADEL 0,5ML",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: NIMENRIX PLV+LSM FSPR 0,5ML.<br>
+     */
+    NIMENRIX_PLV_LSM_FSPR_0_5ML("3909165",
+                                "1.2.40.0.34.4.16.1",
+                                "NIMENRIX PLV+LSM FSPR 0,5ML",
+                                "NIMENRIX PLV+LSM FSPR 0,5ML",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: NUVAXOVID COV19     1x10.<br>
+     */
+    NUVAXOVID_COV19_1X10("5611903",
+                         "1.2.40.0.34.4.16.1",
+                         "NUVAXOVID COV19     1x10",
+                         "NUVAXOVID COV19     1x10",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: NUVAXOVID JN.1 INJ   10x10.<br>
+     */
+    NUVAXOVID_JN_1_INJ_10X10("5540089",
+                             "1.2.40.0.34.4.16.1",
+                             "NUVAXOVID JN.1 INJ   10x10",
+                             "NUVAXOVID JN.1 INJ   10x10",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: NUVAXOVID XBB.1.5 INJ  2x5.<br>
+     */
+    NUVAXOVID_XBB_1_5_INJ_2X5("5526847",
+                              "1.2.40.0.34.4.16.1",
+                              "NUVAXOVID XBB.1.5 INJ  2x5",
+                              "NUVAXOVID XBB.1.5 INJ  2x5",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: OPTAFLU INJ-SUS FSPR.<br>
+     */
+    OPTAFLU_INJ_SUS_FSPR("3911995",
+                         "1.2.40.0.34.4.16.1",
+                         "OPTAFLU INJ-SUS FSPR",
+                         "OPTAFLU INJ-SUS FSPR",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: PFIZER-BION COV19 KONZ30 1x6.<br>
+     */
+    PFIZER_BION_COV19_KONZ30_1X6("5424472",
+                                 "1.2.40.0.34.4.16.1",
+                                 "PFIZER-BION COV19 KONZ30 1x6",
+                                 "PFIZER-BION COV19 KONZ30 1x6",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: PNEUMOVAX 23 DFL 0,5ML.<br>
+     */
+    PNEUMOVAX_23_DFL_0_5ML("4202462",
+                           "1.2.40.0.34.4.16.1",
+                           "PNEUMOVAX 23 DFL 0,5ML",
+                           "PNEUMOVAX 23 DFL 0,5ML",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: PNEUMOVAX 23 FSPR.<br>
+     */
+    PNEUMOVAX_23_FSPR("4209197",
+                      "1.2.40.0.34.4.16.1",
+                      "PNEUMOVAX 23 FSPR",
+                      "PNEUMOVAX 23 FSPR",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: POLIO SALK MER FSPR 0,5ML.<br>
+     */
+    POLIO_SALK_MER_FSPR_0_5ML("1260571",
+                              "1.2.40.0.34.4.16.1",
+                              "POLIO SALK MER FSPR 0,5ML",
+                              "POLIO SALK MER FSPR 0,5ML",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: PREVENAR 13 FSPR 0,5ML+N.<br>
+     */
+    PREVENAR_13_FSPR_0_5ML_N("5511774",
+                             "1.2.40.0.34.4.16.1",
+                             "PREVENAR 13 FSPR 0,5ML+N",
+                             "PREVENAR 13 FSPR 0,5ML+N",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: PREVENAR 13 FSPR 0,5ML+ND.<br>
+     */
+    PREVENAR_13_FSPR_0_5ML_ND("3756589",
+                              "1.2.40.0.34.4.16.1",
+                              "PREVENAR 13 FSPR 0,5ML+ND",
+                              "PREVENAR 13 FSPR 0,5ML+ND",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: PREVENAR 20 FSPR 0,5ML+ND.<br>
+     */
+    PREVENAR_20_FSPR_0_5ML_ND("5520075",
+                              "1.2.40.0.34.4.16.1",
+                              "PREVENAR 20 FSPR 0,5ML+ND",
+                              "PREVENAR 20 FSPR 0,5ML+ND",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: PREVENAR INJ.SUS13 0,5ML+NAD.<br>
+     */
+    PREVENAR_INJ_SUS13_0_5ML_NAD("4477035",
+                                 "1.2.40.0.34.4.16.1",
+                                 "PREVENAR INJ.SUS13 0,5ML+NAD",
+                                 "PREVENAR INJ.SUS13 0,5ML+NAD",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: PRIORIX PLV+LSM IMPFDS.<br>
+     */
+    PRIORIX_PLV_LSM_IMPFDS("1325750",
+                           "1.2.40.0.34.4.16.1",
+                           "PRIORIX PLV+LSM IMPFDS",
+                           "PRIORIX PLV+LSM IMPFDS",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: PRIORIX TETRA PLV DFL FSPR.<br>
+     */
+    PRIORIX_TETRA_PLV_DFL_FSPR("3762986",
+                               "1.2.40.0.34.4.16.1",
+                               "PRIORIX TETRA PLV DFL FSPR",
+                               "PRIORIX TETRA PLV DFL FSPR",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: PROQUAD PLV+LSM FSPR +2K.<br>
+     */
+    PROQUAD_PLV_LSM_FSPR_2K("2472795",
+                            "1.2.40.0.34.4.16.1",
+                            "PROQUAD PLV+LSM FSPR +2K",
+                            "PROQUAD PLV+LSM FSPR +2K",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: QDENGA PLV+LSM IJLSG FSPR+ND.<br>
+     */
+    QDENGA_PLV_LSM_IJLSG_FSPR_ND("5518670",
+                                 "1.2.40.0.34.4.16.1",
+                                 "QDENGA PLV+LSM IJLSG FSPR+ND",
+                                 "QDENGA PLV+LSM IJLSG FSPR+ND",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: QUADRIVALENT INFLUENZA SANOFI 1ST.<br>
+     */
+    QUADRIVALENT_INFLUENZA_SANOFI_1ST("AWEG_000002",
+                                      "1.2.40.0.34.4.16.1",
+                                      "QUADRIVALENT INFLUENZA SANOFI 1ST",
+                                      "QUADRIVALENT INFLUENZA SANOFI 1ST",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: RABIPUR BN PLV+LSM INJ FSPR.<br>
+     */
+    RABIPUR_BN_PLV_LSM_INJ_FSPR("4977737",
+                                "1.2.40.0.34.4.16.1",
+                                "RABIPUR BN PLV+LSM INJ FSPR",
+                                "RABIPUR BN PLV+LSM INJ FSPR",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: RABIPUR GSK PLV+LSM INJ FSPR.<br>
+     */
+    RABIPUR_GSK_PLV_LSM_INJ_FSPR("4465799",
+                                 "1.2.40.0.34.4.16.1",
+                                 "RABIPUR GSK PLV+LSM INJ FSPR",
+                                 "RABIPUR GSK PLV+LSM INJ FSPR",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: RABIPUR PLV LSM 2,5IE/ML.<br>
+     */
+    RABIPUR_PLV_LSM_2_5IE_ML("2454461",
+                             "1.2.40.0.34.4.16.1",
+                             "RABIPUR PLV LSM 2,5IE/ML",
+                             "RABIPUR PLV LSM 2,5IE/ML",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: REPEVAX FSPR 0,5ML+1 KANUELE.<br>
+     */
+    REPEVAX_FSPR_0_5ML_1_KANUELE("2467788",
+                                 "1.2.40.0.34.4.16.1",
+                                 "REPEVAX FSPR 0,5ML+1 KANUELE",
+                                 "REPEVAX FSPR 0,5ML+1 KANUELE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: REPEVAX INJ FSPR 0,5ML O.K.<br>
+     */
+    REPEVAX_INJ_FSPR_0_5ML_O_K("6056875",
+                               "1.2.40.0.34.4.16.1",
+                               "REPEVAX INJ FSPR 0,5ML O.K.",
+                               "REPEVAX INJ FSPR 0,5ML O.K.",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: REVAXIS FSPR 0,5ML+1 KANUELE.<br>
+     */
+    REVAXIS_FSPR_0_5ML_1_KANUELE("2469988",
+                                 "1.2.40.0.34.4.16.1",
+                                 "REVAXIS FSPR 0,5ML+1 KANUELE",
+                                 "REVAXIS FSPR 0,5ML+1 KANUELE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: ROTARIX SUS FAPPLIK.1,5ML.<br>
+     */
+    ROTARIX_SUS_FAPPLIK_1_5ML("3760993",
+                              "1.2.40.0.34.4.16.1",
+                              "ROTARIX SUS FAPPLIK.1,5ML",
+                              "ROTARIX SUS FAPPLIK.1,5ML",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: ROTARIX SUS TUBE 1,5ML.<br>
+     */
+    ROTARIX_SUS_TUBE_1_5ML("4973521",
+                           "1.2.40.0.34.4.16.1",
+                           "ROTARIX SUS TUBE 1,5ML",
+                           "ROTARIX SUS TUBE 1,5ML",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: ROTATEQ QUETSCHTB 2ML.<br>
+     */
+    ROTATEQ_QUETSCHTB_2ML("2472803",
+                          "1.2.40.0.34.4.16.1",
+                          "ROTATEQ QUETSCHTB 2ML",
+                          "ROTATEQ QUETSCHTB 2ML",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: SANDOVAC FSPR 0,5ML.<br>
+     */
+    SANDOVAC_FSPR_0_5ML("1079021",
+                        "1.2.40.0.34.4.16.1",
+                        "SANDOVAC FSPR 0,5ML",
+                        "SANDOVAC FSPR 0,5ML",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: SHINGRIX PLV+SUSP IJSUS DFL.<br>
+     */
+    SHINGRIX_PLV_SUSP_IJSUS_DFL("4983502",
+                                "1.2.40.0.34.4.16.1",
+                                "SHINGRIX PLV+SUSP IJSUS DFL",
+                                "SHINGRIX PLV+SUSP IJSUS DFL",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: SPIKEVAX COV19 BA1   10x1.<br>
+     */
+    SPIKEVAX_COV19_BA1_10X1("5517825",
+                            "1.2.40.0.34.4.16.1",
+                            "SPIKEVAX COV19 BA1   10x1",
+                            "SPIKEVAX COV19 BA1   10x1",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: SPIKEVAX COV19 BA1   10x5.<br>
+     */
+    SPIKEVAX_COV19_BA1_10X5("5517245",
+                            "1.2.40.0.34.4.16.1",
+                            "SPIKEVAX COV19 BA1   10x5",
+                            "SPIKEVAX COV19 BA1   10x5",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: SPIKEVAX COV19 BA1 FSPR 10x1.<br>
+     */
+    SPIKEVAX_COV19_BA1_FSPR_10X1("5517831",
+                                 "1.2.40.0.34.4.16.1",
+                                 "SPIKEVAX COV19 BA1 FSPR 10x1",
+                                 "SPIKEVAX COV19 BA1 FSPR 10x1",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: SPIKEVAX COV19 BA4/5  10x1.<br>
+     */
+    SPIKEVAX_COV19_BA4_5_10X1("5520483",
+                              "1.2.40.0.34.4.16.1",
+                              "SPIKEVAX COV19 BA4/5  10x1",
+                              "SPIKEVAX COV19 BA4/5  10x1",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: SPIKEVAX COV19 BA4/5  10x5.<br>
+     */
+    SPIKEVAX_COV19_BA4_5_10X5("5518730",
+                              "1.2.40.0.34.4.16.1",
+                              "SPIKEVAX COV19 BA4/5  10x5",
+                              "SPIKEVAX COV19 BA4/5  10x5",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: SPIKEVAX XBB.1.5 INJ50  1x1.<br>
+     */
+    SPIKEVAX_XBB_1_5_INJ50_1X1("5526391",
+                               "1.2.40.0.34.4.16.1",
+                               "SPIKEVAX XBB.1.5 INJ50  1x1",
+                               "SPIKEVAX XBB.1.5 INJ50  1x1",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: STAMARIL PLV+LSM DFL+FSPR+1K.<br>
+     */
+    STAMARIL_PLV_LSM_DFL_FSPR_1K("2470017",
+                                 "1.2.40.0.34.4.16.1",
+                                 "STAMARIL PLV+LSM DFL+FSPR+1K",
+                                 "STAMARIL PLV+LSM DFL+FSPR+1K",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: SYNFLORIX FSPR 0,5ML.<br>
+     */
+    SYNFLORIX_FSPR_0_5ML("3533837",
+                         "1.2.40.0.34.4.16.1",
+                         "SYNFLORIX FSPR 0,5ML",
+                         "SYNFLORIX FSPR 0,5ML",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: TD PUR ERW FSPR 0,5ML.<br>
+     */
+    TD_PUR_ERW_FSPR_0_5ML("2228368",
+                          "1.2.40.0.34.4.16.1",
+                          "TD PUR ERW FSPR 0,5ML",
+                          "TD PUR ERW FSPR 0,5ML",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: TD PUR ERW FSPR 0,5ML O.ND.<br>
+     */
+    TD_PUR_ERW_FSPR_0_5ML_O_ND("4989947",
+                               "1.2.40.0.34.4.16.1",
+                               "TD PUR ERW FSPR 0,5ML O.ND",
+                               "TD PUR ERW FSPR 0,5ML O.ND",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: TETANOL PUR FSPR 0,5ML.<br>
+     */
+    TETANOL_PUR_FSPR_0_5ML("0056489",
+                           "1.2.40.0.34.4.16.1",
+                           "TETANOL PUR FSPR 0,5ML",
+                           "TETANOL PUR FSPR 0,5ML",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: TETRAVAC FSPR +2KANUELE.<br>
+     */
+    TETRAVAC_FSPR_2KANUELE("2467794",
+                           "1.2.40.0.34.4.16.1",
+                           "TETRAVAC FSPR +2KANUELE",
+                           "TETRAVAC FSPR +2KANUELE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: TRUMENBA IJSUS FSPR+NAD0,5ML.<br>
+     */
+    TRUMENBA_IJSUS_FSPR_NAD0_5ML("4466942",
+                                 "1.2.40.0.34.4.16.1",
+                                 "TRUMENBA IJSUS FSPR+NAD0,5ML",
+                                 "TRUMENBA IJSUS FSPR+NAD0,5ML",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: TWINRIX ERW INJ FSPR 1ML.<br>
+     */
+    TWINRIX_ERW_INJ_FSPR_1ML("1304498",
+                             "1.2.40.0.34.4.16.1",
+                             "TWINRIX ERW INJ FSPR 1ML",
+                             "TWINRIX ERW INJ FSPR 1ML",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: TWINRIX KIND INF FSPR 0,5ML.<br>
+     */
+    TWINRIX_KIND_INF_FSPR_0_5ML("1309515",
+                                "1.2.40.0.34.4.16.1",
+                                "TWINRIX KIND INF FSPR 0,5ML",
+                                "TWINRIX KIND INF FSPR 0,5ML",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: TYPHERIX IJLSG 25MCG/0,5ML.<br>
+     */
+    TYPHERIX_IJLSG_25MCG_0_5ML("1333991",
+                               "1.2.40.0.34.4.16.1",
+                               "TYPHERIX IJLSG 25MCG/0,5ML",
+                               "TYPHERIX IJLSG 25MCG/0,5ML",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: TYPHIM VI FSPR 0,5ML +1 KAN.<br>
+     */
+    TYPHIM_VI_FSPR_0_5ML_1_KAN("2469994",
+                               "1.2.40.0.34.4.16.1",
+                               "TYPHIM VI FSPR 0,5ML +1 KAN.",
+                               "TYPHIM VI FSPR 0,5ML +1 KAN.",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: VALNEVA COV19     10x10.<br>
+     */
+    VALNEVA_COV19_10X10("5506431",
+                        "1.2.40.0.34.4.16.1",
+                        "VALNEVA COV19     10x10",
+                        "VALNEVA COV19     10x10",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: VAQTA FSPR 50E/1ML+2K.<br>
+     */
+    VAQTA_FSPR_50E_1ML_2K("3904699",
+                          "1.2.40.0.34.4.16.1",
+                          "VAQTA FSPR 50E/1ML+2K",
+                          "VAQTA FSPR 50E/1ML+2K",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: VAQTA-K FSPR 25E/0,5ML+2K.<br>
+     */
+    VAQTA_K_FSPR_25E_0_5ML_2K("3904713",
+                              "1.2.40.0.34.4.16.1",
+                              "VAQTA-K FSPR 25E/0,5ML+2K",
+                              "VAQTA-K FSPR 25E/0,5ML+2K",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: VARILRIX PLV+LSM INJSUSP.<br>
+     */
+    VARILRIX_PLV_LSM_INJSUSP("1316018",
+                             "1.2.40.0.34.4.16.1",
+                             "VARILRIX PLV+LSM INJSUSP",
+                             "VARILRIX PLV+LSM INJSUSP",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: VARIVAX PLV+LSM FSPR.<br>
+     */
+    VARIVAX_PLV_LSM_FSPR("2454923",
+                         "1.2.40.0.34.4.16.1",
+                         "VARIVAX PLV+LSM FSPR",
+                         "VARIVAX PLV+LSM FSPR",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: VARIVAX PLV+LSM FSPR +2KAN.<br>
+     */
+    VARIVAX_PLV_LSM_FSPR_2KAN("4988787",
+                              "1.2.40.0.34.4.16.1",
+                              "VARIVAX PLV+LSM FSPR +2KAN",
+                              "VARIVAX PLV+LSM FSPR +2KAN",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: VAXELIS IJSUS FSPR 0,5ML.<br>
+     */
+    VAXELIS_IJSUS_FSPR_0_5ML("5506945",
+                             "1.2.40.0.34.4.16.1",
+                             "VAXELIS IJSUS FSPR 0,5ML",
+                             "VAXELIS IJSUS FSPR 0,5ML",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: VAXIGRIP FSPR M.KANUELE.<br>
+     */
+    VAXIGRIP_FSPR_M_KANUELE("1076502",
+                            "1.2.40.0.34.4.16.1",
+                            "VAXIGRIP FSPR M.KANUELE",
+                            "VAXIGRIP FSPR M.KANUELE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: VAXIGRIP FSPR O.KANUELE.<br>
+     */
+    VAXIGRIP_FSPR_O_KANUELE("4215720",
+                            "1.2.40.0.34.4.16.1",
+                            "VAXIGRIP FSPR O.KANUELE",
+                            "VAXIGRIP FSPR O.KANUELE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: VAXIGRIP INJ FSPR 0,5ML +1K.<br>
+     */
+    VAXIGRIP_INJ_FSPR_0_5ML_1K("6050105",
+                               "1.2.40.0.34.4.16.1",
+                               "VAXIGRIP INJ FSPR 0,5ML +1K.",
+                               "VAXIGRIP INJ FSPR 0,5ML +1K.",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: VAXIGRIP TETRA FSPR 0,5ML.<br>
+     */
+    VAXIGRIP_TETRA_FSPR_0_5ML("4467841",
+                              "1.2.40.0.34.4.16.1",
+                              "VAXIGRIP TETRA FSPR 0,5ML",
+                              "VAXIGRIP TETRA FSPR 0,5ML",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: VAXIGRIP TETRA FSPR O.K.<br>
+     */
+    VAXIGRIP_TETRA_FSPR_O_K("4467858",
+                            "1.2.40.0.34.4.16.1",
+                            "VAXIGRIP TETRA FSPR O.K",
+                            "VAXIGRIP TETRA FSPR O.K",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: VAXIGRIP TRI FSPR 0,5ML O.K.<br>
+     */
+    VAXIGRIP_TRI_FSPR_0_5ML_O_K("6050111",
+                                "1.2.40.0.34.4.16.1",
+                                "VAXIGRIP TRI FSPR 0,5ML O.K.",
+                                "VAXIGRIP TRI FSPR 0,5ML O.K.",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: VAXNEUVANCE IJSUS FSPR.<br>
+     */
+    VAXNEUVANCE_IJSUS_FSPR("5505414",
+                           "1.2.40.0.34.4.16.1",
+                           "VAXNEUVANCE IJSUS FSPR",
+                           "VAXNEUVANCE IJSUS FSPR",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: VAXZEVRIA COV19    10x10.<br>
+     */
+    VAXZEVRIA_COV19_10X10("4990459",
+                          "1.2.40.0.34.4.16.1",
+                          "VAXZEVRIA COV19    10x10",
+                          "VAXZEVRIA COV19    10x10",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: VERORAB PLV+LSM IJSUS 0,5ML.<br>
+     */
+    VERORAB_PLV_LSM_IJSUS_0_5ML("5523808",
+                                "1.2.40.0.34.4.16.1",
+                                "VERORAB PLV+LSM IJSUS 0,5ML",
+                                "VERORAB PLV+LSM IJSUS 0,5ML",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: VIATIM SUS+LSM IJSUS 2KFSPR.<br>
+     */
+    VIATIM_SUS_LSM_IJSUS_2KFSPR("2434027",
+                                "1.2.40.0.34.4.16.1",
+                                "VIATIM SUS+LSM IJSUS 2KFSPR",
+                                "VIATIM SUS+LSM IJSUS 2KFSPR",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: VIDPREVTYN COV19    10x10.<br>
+     */
+    VIDPREVTYN_COV19_10X10("5517908",
+                           "1.2.40.0.34.4.16.1",
+                           "VIDPREVTYN COV19    10x10",
+                           "VIDPREVTYN COV19    10x10",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: VIVOTIF KPS.<br>
+     */
+    VIVOTIF_KPS("1329251",
+                "1.2.40.0.34.4.16.1",
+                "VIVOTIF KPS",
+                "VIVOTIF KPS",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: VIVOTIF MSR HKPS.<br>
+     */
+    VIVOTIF_MSR_HKPS("4961340",
+                     "1.2.40.0.34.4.16.1",
+                     "VIVOTIF MSR HKPS",
+                     "VIVOTIF MSR HKPS",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: ZBI ZOONOT IFLU SQR FSP0,5ML.<br>
+     */
+    ZBI_ZOONOT_IFLU_SQR_FSP0_5ML("5939880",
+                                 "1.2.40.0.34.4.16.1",
+                                 "ZBI ZOONOT IFLU SQR FSP0,5ML",
+                                 "ZBI ZOONOT IFLU SQR FSP0,5ML",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: ZOSTAVAX PLV +LSM IJSUS FSPR.<br>
+     */
+    ZOSTAVAX_PLV_LSM_IJSUS_FSPR("2472826",
+                                "1.2.40.0.34.4.16.1",
+                                "ZOSTAVAX PLV +LSM IJSUS FSPR",
+                                "ZOSTAVAX PLV +LSM IJSUS FSPR",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE");
+
+    /**
+     * EN: Code for ABRYSVO IJLSG PLV+LSM DFL.<br>
+     */
+    public static final String ABRYSVO_IJLSG_PLV_LSM_DFL_CODE = "5525687";
+
+    /**
+     * EN: Code for ACT-HIB TRSTAMP +LSM.<br>
+     */
+    public static final String ACT_HIB_TRSTAMP_LSM_CODE = "1276939";
+
+    /**
+     * EN: Code for APEXXNAR IJSUS FSPR 0,5ML+ND.<br>
+     */
+    public static final String APEXXNAR_IJSUS_FSPR_0_5ML_ND_CODE = "5508341";
+
+    /**
+     * EN: Code for AREXVY PLV+SUSP IJSUS DFL.<br>
+     */
+    public static final String AREXVY_PLV_SUSP_IJSUS_DFL_CODE = "5525380";
+
+    /**
+     * EN: Code for BEXSERO INJ.SUS FSPR.<br>
+     */
+    public static final String BEXSERO_INJ_SUS_FSPR_CODE = "3920095";
+
+    /**
+     * EN: Code for BEYFORTUS FSP 100MG/1ML O.K.<br>
+     */
+    public static final String BEYFORTUS_FSP_100MG_1ML_O_K_CODE = "5519126";
+
+    /**
+     * EN: Code for BEYFORTUS FSP 50MG/0,5ML O.K.<br>
+     */
+    public static final String BEYFORTUS_FSP_50MG_0_5ML_O_K_CODE = "5519103";
+
+    /**
+     * EN: Code for BOOSTRIX INJ FSPR 0,5ML.<br>
+     */
+    public static final String BOOSTRIX_INJ_FSPR_0_5ML_CODE = "2420746";
+
+    /**
+     * EN: Code for BOOSTRIX POLIO FSPR 0,5ML.<br>
+     */
+    public static final String BOOSTRIX_POLIO_FSPR_0_5ML_CODE = "2457324";
+
+    /**
+     * EN: Code for CAPVAXIVE INJ FSPR 0,5ML +1K.<br>
+     */
+    public static final String CAPVAXIVE_INJ_FSPR_0_5ML_1K_CODE = "6057900";
+
+    /**
+     * EN: Code for CERVARIX FSPR 0,5ML.<br>
+     */
+    public static final String CERVARIX_FSPR_0_5ML_CODE = "3513450";
+
+    /**
+     * EN: Code for COMIRNATY COV19 BA1   10x6.<br>
+     */
+    public static final String COMIRNATY_COV19_BA1_10X6_CODE = "5516837";
+
+    /**
+     * EN: Code for COMIRNATY COV19 BA1  195x6.<br>
+     */
+    public static final String COMIRNATY_COV19_BA1_195X6_CODE = "5516820";
+
+    /**
+     * EN: Code for COMIRNATY COV19 BA4/5  10x6.<br>
+     */
+    public static final String COMIRNATY_COV19_BA4_5_10X6_CODE = "5516866";
+
+    /**
+     * EN: Code for COMIRNATY COV19 BA4/5 195x6.<br>
+     */
+    public static final String COMIRNATY_COV19_BA4_5_195X6_CODE = "5516843";
+
+    /**
+     * EN: Code for COMIRNATY COV19 INJ30  10x6.<br>
+     */
+    public static final String COMIRNATY_COV19_INJ30_10X6_CODE = "5506359";
+
+    /**
+     * EN: Code for COMIRNATY COV19 INJ30 195x6.<br>
+     */
+    public static final String COMIRNATY_COV19_INJ30_195X6_CODE = "5506342";
+
+    /**
+     * EN: Code for COMIRNATY COV19 KONZ10 10x10.<br>
+     */
+    public static final String COMIRNATY_COV19_KONZ10_10X10_CODE = "5506448";
+
+    /**
+     * EN: Code for COMIRNATY COV19 KONZ30 195x6.<br>
+     */
+    public static final String COMIRNATY_COV19_KONZ30_195X6_CODE = "4989539";
+
+    /**
+     * EN: Code for COMIRNATY JN.1 INJ10  10x6.<br>
+     */
+    public static final String COMIRNATY_JN_1_INJ10_10X6_CODE = "5541924";
+
+    /**
+     * EN: Code for COMIRNATY JN.1 INJ30  10x6.<br>
+     */
+    public static final String COMIRNATY_JN_1_INJ30_10X6_CODE = "5541887";
+
+    /**
+     * EN: Code for COMIRNATY JN.1 KO3   10x3.<br>
+     */
+    public static final String COMIRNATY_JN_1_KO3_10X3_CODE = "5541947";
+
+    /**
+     * EN: Code for COMIRNATY KO1,5/1,5  10x10.<br>
+     */
+    public static final String COMIRNATY_KO1_5_1_5_10X10_CODE = "5516990";
+
+    /**
+     * EN: Code for COMIRNATY KO3     10x10.<br>
+     */
+    public static final String COMIRNATY_KO3_10X10_CODE = "5516984";
+
+    /**
+     * EN: Code for COMIRNATY KO5/5 BA4/5 10x10.<br>
+     */
+    public static final String COMIRNATY_KO5_5_BA4_5_10X10_CODE = "5517015";
+
+    /**
+     * EN: Code for COMIRNATY KP.2 INJ10  10x6.<br>
+     */
+    public static final String COMIRNATY_KP_2_INJ10_10X6_CODE = "6051323";
+
+    /**
+     * EN: Code for COMIRNATY KP.2 INJ30  10x6.<br>
+     */
+    public static final String COMIRNATY_KP_2_INJ30_10X6_CODE = "6051317";
+
+    /**
+     * EN: Code for COMIRNATY KP.2 KO3   10x3.<br>
+     */
+    public static final String COMIRNATY_KP_2_KO3_10X3_CODE = "6051346";
+
+    /**
+     * EN: Code for COMIRNATY LP.8.1 INJ10 10x6.<br>
+     */
+    public static final String COMIRNATY_LP_8_1_INJ10_10X6_CODE = "6062373";
+
+    /**
+     * EN: Code for COMIRNATY LP.8.1 INJ30 10x6.<br>
+     */
+    public static final String COMIRNATY_LP_8_1_INJ30_10X6_CODE = "6062367";
+
+    /**
+     * EN: Code for COMIRNATY LP.8.1 KO3  10x3.<br>
+     */
+    public static final String COMIRNATY_LP_8_1_KO3_10X3_CODE = "6062396";
+
+    /**
+     * EN: Code for COMIRNATY XBB.1.5 INJ10 10x6.<br>
+     */
+    public static final String COMIRNATY_XBB_1_5_INJ10_10X6_CODE = "5528243";
+
+    /**
+     * EN: Code for COMIRNATY XBB.1.5 INJ30 10x6.<br>
+     */
+    public static final String COMIRNATY_XBB_1_5_INJ30_10X6_CODE = "5527775";
+
+    /**
+     * EN: Code for COMIRNATY XBB.1.5 KO3 10x10.<br>
+     */
+    public static final String COMIRNATY_XBB_1_5_KO3_10X10_CODE = "5528289";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Abdala (Center for Genetic Engineering and Biotechnology).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_ABDALA_CENTER_FOR_GENETIC_ENGINEERING_AND_BIOTECHNOLOGY_CODE = "AUSL_000016";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff AZD2816 (AstraZeneca AB).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_AZD2816_ASTRAZENECA_AB_CODE = "AUSL_000029";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff BBIBP-CorV (Sinopharm).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_BBIBP_CORV_SINOPHARM_CODE = "AUSL_000006";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Convidecia (CanSino Biologics).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_CONVIDECIA_CANSINO_BIOLOGICS_CODE = "AUSL_000004";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff CoronaVac (Sinovac Biotech).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_CORONAVAC_SINOVAC_BIOTECH_CODE = "AUSL_000008";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Covaxin (Bharat Biotech).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_COVAXIN_BHARAT_BIOTECH_CODE = "AUSL_000009";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Covid-19 (recombinant) (Fiocruz).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_COVID_19_RECOMBINANT_FIOCRUZ_CODE = "AUSL_000011";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Covifenz (Medicago Inc.).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_COVIFENZ_MEDICAGO_INC_CODE = "AUSL_000028";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Covishield (Serum Institute of India).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_COVISHIELD_SERUM_INSTITUTE_OF_INDIA_CODE = "AUSL_000010";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff CoviVac (Chumakov-Federal-Scientific-Center).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_COVIVAC_CHUMAKOV_FEDERAL_SCIENTIFIC_CENTER_CODE = "AUSL_000013";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Covovax (Serum Institute Of India Private Limited).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_COVOVAX_SERUM_INSTITUTE_OF_INDIA_PRIVATE_LIMITED_CODE = "AUSL_000019";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff CVnCoV (CureVac).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_CVNCOV_CUREVAC_CODE = "AUSL_000001";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff EpiVacCorona-N (Vector Institute).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_EPIVACCORONA_N_VECTOR_INSTITUTE_CODE = "AUSL_000022";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff EpiVacCorona (Vektor-Institut).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_EPIVACCORONA_VEKTOR_INSTITUT_CODE = "AUSL_000005";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Hayat-Vax (Gulf Pharmaceutical Industries).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_HAYAT_VAX_GULF_PHARMACEUTICAL_INDUSTRIES_CODE = "AUSL_000015";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Inactivated-SARS-CoV-2-Vero-Cell.<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_INACTIVATED_SARS_COV_2_VERO_CELL_CODE = "AUSL_000007";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff MVC COVID-19 vaccine (Medigen Vaccine Biologics Corporation).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_MVC_COVID_19_VACCINE_MEDIGEN_VACCINE_BIOLOGICS_CORPORATION_CODE = "AUSL_000018";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff NVSI-06-08 (National Vaccine and Serum Institute, China).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_NVSI_06_08_NATIONAL_VACCINE_AND_SERUM_INSTITUTE_CHINA_CODE = "AUSL_000025";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff NVX-CoV2373 (Novavax).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_NVX_COV2373_NOVAVAX_CODE = "AUSL_000002";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff R-COVI (R-Pharm CJSC).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_R_COVI_R_PHARM_CJSC_CODE = "AUSL_000012";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff SCTV01C (Sinocelltech Ltd.).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_SCTV01C_SINOCELLTECH_LTD_CODE = "AUSL_000027";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Soberana 02 (Finlay-Institute).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_SOBERANA_02_FINLAY_INSTITUTE_CODE = "AUSL_000030";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Soberana Plus (Finlay-Institute).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_SOBERANA_PLUS_FINLAY_INSTITUTE_CODE = "AUSL_000031";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Sputnik-Light (Gamaleya).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_SPUTNIK_LIGHT_GAMALEYA_CODE = "AUSL_000014";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Sputnik-M (Gamaleya Research Institute).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_SPUTNIK_M_GAMALEYA_RESEARCH_INSTITUTE_CODE = "AUSL_000023";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Sputnik-V (Gamaleya).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_SPUTNIK_V_GAMALEYA_CODE = "AUSL_000003";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Vacina adsorvida covid-19 (inativada) (Instituto Butantan).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_VACINA_ADSORVIDA_COVID_19_INATIVADA_INSTITUTO_BUTANTAN_CODE = "AUSL_000024";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff Vidprevtyn (Sanofi Pasteur).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_VIDPREVTYN_SANOFI_PASTEUR_CODE = "AUSL_000020";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff VLA2001 (Valneva France).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_VLA2001_VALNEVA_FRANCE_CODE = "AUSL_000021";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff WIBP-CorV (Sinopharm - Wuhan Institute of Biological Products).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_WIBP_CORV_SINOPHARM_WUHAN_INSTITUTE_OF_BIOLOGICAL_PRODUCTS_CODE = "AUSL_000017";
+
+    /**
+     * EN: Code for COVID-19-Impfstoff YS-SC2-010 (Yisheng Biopharma).<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_YS_SC2_010_YISHENG_BIOPHARMA_CODE = "AUSL_000026";
+
+    /**
+     * EN: Code for DTAP BOOSTER FSPR 0,5ML.<br>
+     */
+    public static final String DTAP_BOOSTER_FSPR_0_5ML_CODE = "5543308";
+
+    /**
+     * EN: Code for DT-REDUCT MER FSPR 0,5ML.<br>
+     */
+    public static final String DT_REDUCT_MER_FSPR_0_5ML_CODE = "1290520";
+
+    /**
+     * EN: Code for DUKORAL SUSP+BRGRAN 2X1DOSIS.<br>
+     */
+    public static final String DUKORAL_SUSP_BRGRAN_2X1DOSIS_CODE = "2465140";
+
+    /**
+     * EN: Code for EFLUELDA TETRA FSP 0,7ML O.K.<br>
+     */
+    public static final String EFLUELDA_TETRA_FSP_0_7ML_O_K_CODE = "4989918";
+
+    /**
+     * EN: Code for EFLUELDA TRIVA FSP 0,5ML O.K.<br>
+     */
+    public static final String EFLUELDA_TRIVA_FSP_0_5ML_O_K_CODE = "6050128";
+
+    /**
+     * EN: Code for ENCEPUR FSPR 0,25ML KIND.<br>
+     */
+    public static final String ENCEPUR_FSPR_0_25ML_KIND_CODE = "2427872";
+
+    /**
+     * EN: Code for ENCEPUR FSPR 0,25ML KIND BN.<br>
+     */
+    public static final String ENCEPUR_FSPR_0_25ML_KIND_BN_CODE = "4977720";
+
+    /**
+     * EN: Code for ENCEPUR FSPR 0,25ML KIND +ND.<br>
+     */
+    public static final String ENCEPUR_FSPR_0_25ML_KIND_ND_CODE = "4977134";
+
+    /**
+     * EN: Code for ENCEPUR FSPR 0,5ML.<br>
+     */
+    public static final String ENCEPUR_FSPR_0_5ML_CODE = "2246975";
+
+    /**
+     * EN: Code for ENCEPUR FSPR 0,5ML BN.<br>
+     */
+    public static final String ENCEPUR_FSPR_0_5ML_BN_CODE = "4977714";
+
+    /**
+     * EN: Code for ENCEPUR FSPR 0,5ML +ND.<br>
+     */
+    public static final String ENCEPUR_FSPR_0_5ML_ND_CODE = "4977140";
+
+    /**
+     * EN: Code for ENGERIX-B FSPR 10MCG/0,5ML.<br>
+     */
+    public static final String ENGERIX_B_FSPR_10MCG_0_5ML_CODE = "1292200";
+
+    /**
+     * EN: Code for ENGERIX-B FSPR 20MCG/1ML.<br>
+     */
+    public static final String ENGERIX_B_FSPR_20MCG_1ML_CODE = "1364721";
+
+    /**
+     * EN: Code for FLUAD FSPR 0,5ML.<br>
+     */
+    public static final String FLUAD_FSPR_0_5ML_CODE = "1349762";
+
+    /**
+     * EN: Code for FLUAD IJSUS FSPR 0,5ML.<br>
+     */
+    public static final String FLUAD_IJSUS_FSPR_0_5ML_CODE = "6054586";
+
+    /**
+     * EN: Code for FLUAD TETRA FSPR 0,5ML.<br>
+     */
+    public static final String FLUAD_TETRA_FSPR_0_5ML_CODE = "5509702";
+
+    /**
+     * EN: Code for FLUAD TETRA FSPR+ND 0,5ML.<br>
+     */
+    public static final String FLUAD_TETRA_FSPR_ND_0_5ML_CODE = "4990123";
+
+    /**
+     * EN: Code for FLUARIX INJ.SUS FSPR O.NADEL.<br>
+     */
+    public static final String FLUARIX_INJ_SUS_FSPR_O_NADEL_CODE = "3927186";
+
+    /**
+     * EN: Code for FLUARIX TETRA FSPR +2ND.<br>
+     */
+    public static final String FLUARIX_TETRA_FSPR_2ND_CODE = "4205785";
+
+    /**
+     * EN: Code for FLUCELVAX IJSUS FSPR 0,5ML.<br>
+     */
+    public static final String FLUCELVAX_IJSUS_FSPR_0_5ML_CODE = "6054592";
+
+    /**
+     * EN: Code for FLUCELVAX TETRA FSPR 0,5ML.<br>
+     */
+    public static final String FLUCELVAX_TETRA_FSPR_0_5ML_CODE = "4963675";
+
+    /**
+     * EN: Code for FLUCELVAX TETRA IJSUS FSPR.<br>
+     */
+    public static final String FLUCELVAX_TETRA_IJSUS_FSPR_CODE = "4963681";
+
+    /**
+     * EN: Code for FLUENZ NA-SPRAY.<br>
+     */
+    public static final String FLUENZ_NA_SPRAY_CODE = "5536975";
+
+    /**
+     * EN: Code for FLUENZ TETRA NA-SPRAY.<br>
+     */
+    public static final String FLUENZ_TETRA_NA_SPRAY_CODE = "4202025";
+
+    /**
+     * EN: Code for FLUVACCINOL INJ-SUS FSPR.<br>
+     */
+    public static final String FLUVACCINOL_INJ_SUS_FSPR_CODE = "3528434";
+
+    /**
+     * EN: Code for FLUZONE/EFLUELDA 10St.<br>
+     */
+    public static final String FLUZONE_EFLUELDA_10ST_CODE = "AWEG_000001";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,25ML.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_25ML_CODE = "3925655";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,25ML NAD B.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_25ML_NAD_B_CODE = "3925649";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,25ML NAD F.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_25ML_NAD_F_CODE = "2427180";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,25ML+S.NAD.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_25ML_S_NAD_CODE = "4209702";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,5ML.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_5ML_CODE = "3932454";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,5ML NAD B.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_5ML_NAD_B_CODE = "3932448";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,5ML NAD F.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_5ML_NAD_F_CODE = "0514986";
+
+    /**
+     * EN: Code for FSME-IMMUN FSPR 0,5ML+S.NAD.<br>
+     */
+    public static final String FSME_IMMUN_FSPR_0_5ML_S_NAD_CODE = "4209694";
+
+    /**
+     * EN: Code for GARDASIL 9 FSPR +2KAN.<br>
+     */
+    public static final String GARDASIL_9_FSPR_2KAN_CODE = "4224707";
+
+    /**
+     * EN: Code for GARDASIL SPR +2KAN.<br>
+     */
+    public static final String GARDASIL_SPR_2KAN_CODE = "3514171";
+
+    /**
+     * EN: Code for HAVRIX FSPR 1440 ERW.<br>
+     */
+    public static final String HAVRIX_FSPR_1440_ERW_CODE = "1301057";
+
+    /**
+     * EN: Code for HAVRIX FSPR 720 JUNIOR.<br>
+     */
+    public static final String HAVRIX_FSPR_720_JUNIOR_CODE = "1315496";
+
+    /**
+     * EN: Code for HBVAXPRO IJSUS FLA 40MCG.<br>
+     */
+    public static final String HBVAXPRO_IJSUS_FLA_40MCG_CODE = "1350268";
+
+    /**
+     * EN: Code for HBVAXPRO IJSUS FSP 10MCG 2KN.<br>
+     */
+    public static final String HBVAXPRO_IJSUS_FSP_10MCG_2KN_CODE = "3519599";
+
+    /**
+     * EN: Code for HBVAXPRO IJSUS FSP 5MCG 2KN.<br>
+     */
+    public static final String HBVAXPRO_IJSUS_FSP_5MCG_2KN_CODE = "2467765";
+
+    /**
+     * EN: Code for HEPATYRIX IJSUS FSPR.<br>
+     */
+    public static final String HEPATYRIX_IJSUS_FSPR_CODE = "2442831";
+
+    /**
+     * EN: Code for HEXYON IJSUS FSPR +2 KAN.<br>
+     */
+    public static final String HEXYON_IJSUS_FSPR_2_KAN_CODE = "3928168";
+
+    /**
+     * EN: Code for IAA FLUAD TETRA FSPR 0,5ML.<br>
+     */
+    public static final String IAA_FLUAD_TETRA_FSPR_0_5ML_CODE = "5801437";
+
+    /**
+     * EN: Code for IAA FLUARIX TETRA FSPR +2ND.<br>
+     */
+    public static final String IAA_FLUARIX_TETRA_FSPR_2ND_CODE = "5801495";
+
+    /**
+     * EN: Code for IAA FLUENZ TETRA NA-SPRAY.<br>
+     */
+    public static final String IAA_FLUENZ_TETRA_NA_SPRAY_CODE = "5801354";
+
+    /**
+     * EN: Code for IAA VAXIGRIP TETRA FSPR O.K.<br>
+     */
+    public static final String IAA_VAXIGRIP_TETRA_FSPR_O_K_CODE = "5801472";
+
+    /**
+     * EN: Code for IMVANEX 20ST.<br>
+     */
+    public static final String IMVANEX_20ST_CODE = "AWEG_000005";
+
+    /**
+     * EN: Code for INFANRIX HEXA PLV INJS FSPR.<br>
+     */
+    public static final String INFANRIX_HEXA_PLV_INJS_FSPR_CODE = "2479314";
+
+    /**
+     * EN: Code for INFLUSPLIT TETRA 1ST.<br>
+     */
+    public static final String INFLUSPLIT_TETRA_1ST_CODE = "AWEG_000003";
+
+    /**
+     * EN: Code for INFLUVAC FSPR 0,5ML.<br>
+     */
+    public static final String INFLUVAC_FSPR_0_5ML_CODE = "1258120";
+
+    /**
+     * EN: Code for INFLUVAC FSPR 0,5ML O.KANUEL.<br>
+     */
+    public static final String INFLUVAC_FSPR_0_5ML_O_KANUEL_CODE = "1265597";
+
+    /**
+     * EN: Code for INFLUVAC TETRA FSPR0,5ML M.K.<br>
+     */
+    public static final String INFLUVAC_TETRA_FSPR0_5ML_M_K_CODE = "4482993";
+
+    /**
+     * EN: Code for INFLUVAC TETRA FSPR0,5ML O.K.<br>
+     */
+    public static final String INFLUVAC_TETRA_FSPR0_5ML_O_K_CODE = "5534491";
+
+    /**
+     * EN: Code for INFLUVAC TRI FSPR 0,5ML O.K.<br>
+     */
+    public static final String INFLUVAC_TRI_FSPR_0_5ML_O_K_CODE = "6052771";
+
+    /**
+     * EN: Code for INTANZA 15MCG FSPR.<br>
+     */
+    public static final String INTANZA_15MCG_FSPR_CODE = "3539969";
+
+    /**
+     * EN: Code for INTANZA 9MCG FSPR.<br>
+     */
+    public static final String INTANZA_9MCG_FSPR_CODE = "3761739";
+
+    /**
+     * EN: Code for IXCHIQ INJ PLV+LSM FSP 0,5ML.<br>
+     */
+    public static final String IXCHIQ_INJ_PLV_LSM_FSP_0_5ML_CODE = "5534284";
+
+    /**
+     * EN: Code for IXIARO FSPR.<br>
+     */
+    public static final String IXIARO_FSPR_CODE = "3537551";
+
+    /**
+     * EN: Code for JCOVDEN COV19      10x5.<br>
+     */
+    public static final String JCOVDEN_COV19_10X5_CODE = "4991720";
+
+    /**
+     * EN: Code for JCOVDEN COV19      20x5.<br>
+     */
+    public static final String JCOVDEN_COV19_20X5_CODE = "5502522";
+
+    /**
+     * EN: Code for JYNNEOS 20ST.<br>
+     */
+    public static final String JYNNEOS_20ST_CODE = "AWEG_000004";
+
+    /**
+     * EN: Code for MENJUGATE INJ FSPR 10MCG.<br>
+     */
+    public static final String MENJUGATE_INJ_FSPR_10MCG_CODE = "4453106";
+
+    /**
+     * EN: Code for MENJUGATE PLV +LSM FSPR.<br>
+     */
+    public static final String MENJUGATE_PLV_LSM_FSPR_CODE = "3521662";
+
+    /**
+     * EN: Code for MENVEO PLV+LSM DFL.<br>
+     */
+    public static final String MENVEO_PLV_LSM_DFL_CODE = "3782291";
+
+    /**
+     * EN: Code for MMRVAXPRO PLV+LSM FSPR +2K.<br>
+     */
+    public static final String MMRVAXPRO_PLV_LSM_FSPR_2K_CODE = "3511764";
+
+    /**
+     * EN: Code for MODERNA/SPIKEVAX COV19 10x10.<br>
+     */
+    public static final String MODERNA_SPIKEVAX_COV19_10X10_CODE = "5426873";
+
+    /**
+     * EN: Code for MODERNA/SPIKEVAX COV19 1x10.<br>
+     */
+    public static final String MODERNA_SPIKEVAX_COV19_1X10_CODE = "5426867";
+
+    /**
+     * EN: Code for NEISVAC-C FSPR 2 NADEL 0,5ML.<br>
+     */
+    public static final String NEISVAC_C_FSPR_2_NADEL_0_5ML_CODE = "3532424";
+
+    /**
+     * EN: Code for NIMENRIX PLV+LSM FSPR 0,5ML.<br>
+     */
+    public static final String NIMENRIX_PLV_LSM_FSPR_0_5ML_CODE = "3909165";
+
+    /**
+     * EN: Code for NUVAXOVID COV19     1x10.<br>
+     */
+    public static final String NUVAXOVID_COV19_1X10_CODE = "5611903";
+
+    /**
+     * EN: Code for NUVAXOVID JN.1 INJ   10x10.<br>
+     */
+    public static final String NUVAXOVID_JN_1_INJ_10X10_CODE = "5540089";
+
+    /**
+     * EN: Code for NUVAXOVID XBB.1.5 INJ  2x5.<br>
+     */
+    public static final String NUVAXOVID_XBB_1_5_INJ_2X5_CODE = "5526847";
+
+    /**
+     * EN: Code for OPTAFLU INJ-SUS FSPR.<br>
+     */
+    public static final String OPTAFLU_INJ_SUS_FSPR_CODE = "3911995";
+
+    /**
+     * EN: Code for PFIZER-BION COV19 KONZ30 1x6.<br>
+     */
+    public static final String PFIZER_BION_COV19_KONZ30_1X6_CODE = "5424472";
+
+    /**
+     * EN: Code for PNEUMOVAX 23 DFL 0,5ML.<br>
+     */
+    public static final String PNEUMOVAX_23_DFL_0_5ML_CODE = "4202462";
+
+    /**
+     * EN: Code for PNEUMOVAX 23 FSPR.<br>
+     */
+    public static final String PNEUMOVAX_23_FSPR_CODE = "4209197";
+
+    /**
+     * EN: Code for POLIO SALK MER FSPR 0,5ML.<br>
+     */
+    public static final String POLIO_SALK_MER_FSPR_0_5ML_CODE = "1260571";
+
+    /**
+     * EN: Code for PREVENAR 13 FSPR 0,5ML+N.<br>
+     */
+    public static final String PREVENAR_13_FSPR_0_5ML_N_CODE = "5511774";
+
+    /**
+     * EN: Code for PREVENAR 13 FSPR 0,5ML+ND.<br>
+     */
+    public static final String PREVENAR_13_FSPR_0_5ML_ND_CODE = "3756589";
+
+    /**
+     * EN: Code for PREVENAR 20 FSPR 0,5ML+ND.<br>
+     */
+    public static final String PREVENAR_20_FSPR_0_5ML_ND_CODE = "5520075";
+
+    /**
+     * EN: Code for PREVENAR INJ.SUS13 0,5ML+NAD.<br>
+     */
+    public static final String PREVENAR_INJ_SUS13_0_5ML_NAD_CODE = "4477035";
+
+    /**
+     * EN: Code for PRIORIX PLV+LSM IMPFDS.<br>
+     */
+    public static final String PRIORIX_PLV_LSM_IMPFDS_CODE = "1325750";
+
+    /**
+     * EN: Code for PRIORIX TETRA PLV DFL FSPR.<br>
+     */
+    public static final String PRIORIX_TETRA_PLV_DFL_FSPR_CODE = "3762986";
+
+    /**
+     * EN: Code for PROQUAD PLV+LSM FSPR +2K.<br>
+     */
+    public static final String PROQUAD_PLV_LSM_FSPR_2K_CODE = "2472795";
+
+    /**
+     * EN: Code for QDENGA PLV+LSM IJLSG FSPR+ND.<br>
+     */
+    public static final String QDENGA_PLV_LSM_IJLSG_FSPR_ND_CODE = "5518670";
+
+    /**
+     * EN: Code for QUADRIVALENT INFLUENZA SANOFI 1ST.<br>
+     */
+    public static final String QUADRIVALENT_INFLUENZA_SANOFI_1ST_CODE = "AWEG_000002";
+
+    /**
+     * EN: Code for RABIPUR BN PLV+LSM INJ FSPR.<br>
+     */
+    public static final String RABIPUR_BN_PLV_LSM_INJ_FSPR_CODE = "4977737";
+
+    /**
+     * EN: Code for RABIPUR GSK PLV+LSM INJ FSPR.<br>
+     */
+    public static final String RABIPUR_GSK_PLV_LSM_INJ_FSPR_CODE = "4465799";
+
+    /**
+     * EN: Code for RABIPUR PLV LSM 2,5IE/ML.<br>
+     */
+    public static final String RABIPUR_PLV_LSM_2_5IE_ML_CODE = "2454461";
+
+    /**
+     * EN: Code for REPEVAX FSPR 0,5ML+1 KANUELE.<br>
+     */
+    public static final String REPEVAX_FSPR_0_5ML_1_KANUELE_CODE = "2467788";
+
+    /**
+     * EN: Code for REPEVAX INJ FSPR 0,5ML O.K.<br>
+     */
+    public static final String REPEVAX_INJ_FSPR_0_5ML_O_K_CODE = "6056875";
+
+    /**
+     * EN: Code for REVAXIS FSPR 0,5ML+1 KANUELE.<br>
+     */
+    public static final String REVAXIS_FSPR_0_5ML_1_KANUELE_CODE = "2469988";
+
+    /**
+     * EN: Code for ROTARIX SUS FAPPLIK.1,5ML.<br>
+     */
+    public static final String ROTARIX_SUS_FAPPLIK_1_5ML_CODE = "3760993";
+
+    /**
+     * EN: Code for ROTARIX SUS TUBE 1,5ML.<br>
+     */
+    public static final String ROTARIX_SUS_TUBE_1_5ML_CODE = "4973521";
+
+    /**
+     * EN: Code for ROTATEQ QUETSCHTB 2ML.<br>
+     */
+    public static final String ROTATEQ_QUETSCHTB_2ML_CODE = "2472803";
+
+    /**
+     * EN: Code for SANDOVAC FSPR 0,5ML.<br>
+     */
+    public static final String SANDOVAC_FSPR_0_5ML_CODE = "1079021";
+
+    /**
+     * EN: Code for SHINGRIX PLV+SUSP IJSUS DFL.<br>
+     */
+    public static final String SHINGRIX_PLV_SUSP_IJSUS_DFL_CODE = "4983502";
+
+    /**
+     * EN: Code for SPIKEVAX COV19 BA1   10x1.<br>
+     */
+    public static final String SPIKEVAX_COV19_BA1_10X1_CODE = "5517825";
+
+    /**
+     * EN: Code for SPIKEVAX COV19 BA1   10x5.<br>
+     */
+    public static final String SPIKEVAX_COV19_BA1_10X5_CODE = "5517245";
+
+    /**
+     * EN: Code for SPIKEVAX COV19 BA1 FSPR 10x1.<br>
+     */
+    public static final String SPIKEVAX_COV19_BA1_FSPR_10X1_CODE = "5517831";
+
+    /**
+     * EN: Code for SPIKEVAX COV19 BA4/5  10x1.<br>
+     */
+    public static final String SPIKEVAX_COV19_BA4_5_10X1_CODE = "5520483";
+
+    /**
+     * EN: Code for SPIKEVAX COV19 BA4/5  10x5.<br>
+     */
+    public static final String SPIKEVAX_COV19_BA4_5_10X5_CODE = "5518730";
+
+    /**
+     * EN: Code for SPIKEVAX XBB.1.5 INJ50  1x1.<br>
+     */
+    public static final String SPIKEVAX_XBB_1_5_INJ50_1X1_CODE = "5526391";
+
+    /**
+     * EN: Code for STAMARIL PLV+LSM DFL+FSPR+1K.<br>
+     */
+    public static final String STAMARIL_PLV_LSM_DFL_FSPR_1K_CODE = "2470017";
+
+    /**
+     * EN: Code for SYNFLORIX FSPR 0,5ML.<br>
+     */
+    public static final String SYNFLORIX_FSPR_0_5ML_CODE = "3533837";
+
+    /**
+     * EN: Code for TD PUR ERW FSPR 0,5ML.<br>
+     */
+    public static final String TD_PUR_ERW_FSPR_0_5ML_CODE = "2228368";
+
+    /**
+     * EN: Code for TD PUR ERW FSPR 0,5ML O.ND.<br>
+     */
+    public static final String TD_PUR_ERW_FSPR_0_5ML_O_ND_CODE = "4989947";
+
+    /**
+     * EN: Code for TETANOL PUR FSPR 0,5ML.<br>
+     */
+    public static final String TETANOL_PUR_FSPR_0_5ML_CODE = "0056489";
+
+    /**
+     * EN: Code for TETRAVAC FSPR +2KANUELE.<br>
+     */
+    public static final String TETRAVAC_FSPR_2KANUELE_CODE = "2467794";
+
+    /**
+     * EN: Code for TRUMENBA IJSUS FSPR+NAD0,5ML.<br>
+     */
+    public static final String TRUMENBA_IJSUS_FSPR_NAD0_5ML_CODE = "4466942";
+
+    /**
+     * EN: Code for TWINRIX ERW INJ FSPR 1ML.<br>
+     */
+    public static final String TWINRIX_ERW_INJ_FSPR_1ML_CODE = "1304498";
+
+    /**
+     * EN: Code for TWINRIX KIND INF FSPR 0,5ML.<br>
+     */
+    public static final String TWINRIX_KIND_INF_FSPR_0_5ML_CODE = "1309515";
+
+    /**
+     * EN: Code for TYPHERIX IJLSG 25MCG/0,5ML.<br>
+     */
+    public static final String TYPHERIX_IJLSG_25MCG_0_5ML_CODE = "1333991";
+
+    /**
+     * EN: Code for TYPHIM VI FSPR 0,5ML +1 KAN.<br>
+     */
+    public static final String TYPHIM_VI_FSPR_0_5ML_1_KAN_CODE = "2469994";
+
+    /**
+     * EN: Code for VALNEVA COV19     10x10.<br>
+     */
+    public static final String VALNEVA_COV19_10X10_CODE = "5506431";
+
+    /**
+     * EN: Code for VAQTA FSPR 50E/1ML+2K.<br>
+     */
+    public static final String VAQTA_FSPR_50E_1ML_2K_CODE = "3904699";
+
+    /**
+     * EN: Code for VAQTA-K FSPR 25E/0,5ML+2K.<br>
+     */
+    public static final String VAQTA_K_FSPR_25E_0_5ML_2K_CODE = "3904713";
+
+    /**
+     * EN: Code for VARILRIX PLV+LSM INJSUSP.<br>
+     */
+    public static final String VARILRIX_PLV_LSM_INJSUSP_CODE = "1316018";
+
+    /**
+     * EN: Code for VARIVAX PLV+LSM FSPR.<br>
+     */
+    public static final String VARIVAX_PLV_LSM_FSPR_CODE = "2454923";
+
+    /**
+     * EN: Code for VARIVAX PLV+LSM FSPR +2KAN.<br>
+     */
+    public static final String VARIVAX_PLV_LSM_FSPR_2KAN_CODE = "4988787";
+
+    /**
+     * EN: Code for VAXELIS IJSUS FSPR 0,5ML.<br>
+     */
+    public static final String VAXELIS_IJSUS_FSPR_0_5ML_CODE = "5506945";
+
+    /**
+     * EN: Code for VAXIGRIP FSPR M.KANUELE.<br>
+     */
+    public static final String VAXIGRIP_FSPR_M_KANUELE_CODE = "1076502";
+
+    /**
+     * EN: Code for VAXIGRIP FSPR O.KANUELE.<br>
+     */
+    public static final String VAXIGRIP_FSPR_O_KANUELE_CODE = "4215720";
+
+    /**
+     * EN: Code for VAXIGRIP INJ FSPR 0,5ML +1K.<br>
+     */
+    public static final String VAXIGRIP_INJ_FSPR_0_5ML_1K_CODE = "6050105";
+
+    /**
+     * EN: Code for VAXIGRIP TETRA FSPR 0,5ML.<br>
+     */
+    public static final String VAXIGRIP_TETRA_FSPR_0_5ML_CODE = "4467841";
+
+    /**
+     * EN: Code for VAXIGRIP TETRA FSPR O.K.<br>
+     */
+    public static final String VAXIGRIP_TETRA_FSPR_O_K_CODE = "4467858";
+
+    /**
+     * EN: Code for VAXIGRIP TRI FSPR 0,5ML O.K.<br>
+     */
+    public static final String VAXIGRIP_TRI_FSPR_0_5ML_O_K_CODE = "6050111";
+
+    /**
+     * EN: Code for VAXNEUVANCE IJSUS FSPR.<br>
+     */
+    public static final String VAXNEUVANCE_IJSUS_FSPR_CODE = "5505414";
+
+    /**
+     * EN: Code for VAXZEVRIA COV19    10x10.<br>
+     */
+    public static final String VAXZEVRIA_COV19_10X10_CODE = "4990459";
+
+    /**
+     * EN: Code for VERORAB PLV+LSM IJSUS 0,5ML.<br>
+     */
+    public static final String VERORAB_PLV_LSM_IJSUS_0_5ML_CODE = "5523808";
+
+    /**
+     * EN: Code for VIATIM SUS+LSM IJSUS 2KFSPR.<br>
+     */
+    public static final String VIATIM_SUS_LSM_IJSUS_2KFSPR_CODE = "2434027";
+
+    /**
+     * EN: Code for VIDPREVTYN COV19    10x10.<br>
+     */
+    public static final String VIDPREVTYN_COV19_10X10_CODE = "5517908";
+
+    /**
+     * EN: Code for VIVOTIF KPS.<br>
+     */
+    public static final String VIVOTIF_KPS_CODE = "1329251";
+
+    /**
+     * EN: Code for VIVOTIF MSR HKPS.<br>
+     */
+    public static final String VIVOTIF_MSR_HKPS_CODE = "4961340";
+
+    /**
+     * EN: Code for ZBI ZOONOT IFLU SQR FSP0,5ML.<br>
+     */
+    public static final String ZBI_ZOONOT_IFLU_SQR_FSP0_5ML_CODE = "5939880";
+
+    /**
+     * EN: Code for ZOSTAVAX PLV +LSM IJSUS FSPR.<br>
+     */
+    public static final String ZOSTAVAX_PLV_LSM_IJSUS_FSPR_CODE = "2472826";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.14";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-impfstoffe";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.4.16.1";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfImpfstoffe getEnum(@Nullable final String code) {
+        for (final EimpfImpfstoffe x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfImpfstoffe.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfImpfstoffe x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfImpfstoffe(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfMedikationartanwendung.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfMedikationartanwendung.java
@@ -1,0 +1,373 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-medikationartanwendung values
+ * <p>
+ * EN: No designation found.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.96<br>
+ * Effective date: 2024-10-28 11:52<br>
+ * Version: 1.2.0+20250130<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfMedikationartanwendung implements ValueSetEnumInterface {
+
+    /**
+     * EN: intradermale Anwendung.<br>
+     */
+    INTRADERMALE_ANWENDUNG("100000073595",
+                           "1.2.40.0.10.1.4.3.4.3.4",
+                           "intradermale Anwendung",
+                           "intradermale Anwendung",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Intradermale Anwendungsart.<br>
+     */
+    INTRADERMALE_ANWENDUNGSART("372464004",
+                               "2.16.840.1.113883.6.96",
+                               "Intradermale Anwendungsart",
+                               "Intradermale Anwendungsart",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: intramuskuläre Anwendung.<br>
+     */
+    INTRAMUSKUL_RE_ANWENDUNG("100000073600",
+                             "1.2.40.0.10.1.4.3.4.3.4",
+                             "intramuskuläre Anwendung",
+                             "intramuskuläre Anwendung",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Intramuskuläre Anwendungsart.<br>
+     */
+    INTRAMUSKUL_RE_ANWENDUNGSART("78421000",
+                                 "2.16.840.1.113883.6.96",
+                                 "Intramuskuläre Anwendungsart",
+                                 "Intramuskuläre Anwendungsart",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: nasale Anwendung.<br>
+     */
+    NASALE_ANWENDUNG("100000073615",
+                     "1.2.40.0.10.1.4.3.4.3.4",
+                     "nasale Anwendung",
+                     "nasale Anwendung",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Nasale Anwendungsart.<br>
+     */
+    NASALE_ANWENDUNGSART("46713006",
+                         "2.16.840.1.113883.6.96",
+                         "Nasale Anwendungsart",
+                         "Nasale Anwendungsart",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Orale Anwendungsart.<br>
+     */
+    ORALE_ANWENDUNGSART("26643006",
+                        "2.16.840.1.113883.6.96",
+                        "Orale Anwendungsart",
+                        "Orale Anwendungsart",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: subkutane Anwendung.<br>
+     */
+    SUBKUTANE_ANWENDUNG("100000073633",
+                        "1.2.40.0.10.1.4.3.4.3.4",
+                        "subkutane Anwendung",
+                        "subkutane Anwendung",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Subkutane Anwendungsart.<br>
+     */
+    SUBKUTANE_ANWENDUNGSART("34206005",
+                            "2.16.840.1.113883.6.96",
+                            "Subkutane Anwendungsart",
+                            "Subkutane Anwendungsart",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: zum Einnehmen.<br>
+     */
+    ZUM_EINNEHMEN("100000073619",
+                  "1.2.40.0.10.1.4.3.4.3.4",
+                  "zum Einnehmen",
+                  "zum Einnehmen",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE");
+
+    /**
+     * EN: Code for intradermale Anwendung.<br>
+     */
+    public static final String INTRADERMALE_ANWENDUNG_CODE = "100000073595";
+
+    /**
+     * EN: Code for Intradermale Anwendungsart.<br>
+     */
+    public static final String INTRADERMALE_ANWENDUNGSART_CODE = "372464004";
+
+    /**
+     * EN: Code for intramuskuläre Anwendung.<br>
+     */
+    public static final String INTRAMUSKUL_RE_ANWENDUNG_CODE = "100000073600";
+
+    /**
+     * EN: Code for Intramuskuläre Anwendungsart.<br>
+     */
+    public static final String INTRAMUSKUL_RE_ANWENDUNGSART_CODE = "78421000";
+
+    /**
+     * EN: Code for nasale Anwendung.<br>
+     */
+    public static final String NASALE_ANWENDUNG_CODE = "100000073615";
+
+    /**
+     * EN: Code for Nasale Anwendungsart.<br>
+     */
+    public static final String NASALE_ANWENDUNGSART_CODE = "46713006";
+
+    /**
+     * EN: Code for Orale Anwendungsart.<br>
+     */
+    public static final String ORALE_ANWENDUNGSART_CODE = "26643006";
+
+    /**
+     * EN: Code for subkutane Anwendung.<br>
+     */
+    public static final String SUBKUTANE_ANWENDUNG_CODE = "100000073633";
+
+    /**
+     * EN: Code for Subkutane Anwendungsart.<br>
+     */
+    public static final String SUBKUTANE_ANWENDUNGSART_CODE = "34206005";
+
+    /**
+     * EN: Code for zum Einnehmen.<br>
+     */
+    public static final String ZUM_EINNEHMEN_CODE = "100000073619";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.96";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-medikationartanwendung";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfMedikationartanwendung getEnum(@Nullable final String code) {
+        for (final EimpfMedikationartanwendung x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfMedikationartanwendung.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfMedikationartanwendung x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfMedikationartanwendung(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfSpecialcasevaccination.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfSpecialcasevaccination.java
@@ -1,0 +1,498 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-specialcasevaccination values
+ * <p>
+ * EN: Special cases for vaccination entries (Immunization Entry, Immunization Recommendation Entry). Contains information protected by copyright of SNOMED International. Any use of SNOMED CT in Austria requires a valid affiliate license or sublicense. The corresponding license is free of charge, provided that the use only takes place in Austria and fulfills the conditions of the Affiliate License Agreement. Affiliate licenses can be requested directly from the respective NRC via the Member Licensing and Distribution Service (MLDS). https://mlds.ihtsdotools.org/#/landing/AT?lang=de.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.3<br>
+ * Effective date: 2022-06-10 00:00<br>
+ * Version: 202206(-beta)<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfSpecialcasevaccination implements ValueSetEnumInterface {
+
+    /**
+     * EN: Ausnahme.<br>
+     */
+    AUSNAHME("_Ausnahme",
+             "1.2.40.0.34.5.183",
+             "Ausnahme",
+             "Ausnahme",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Blau.<br>
+     */
+    BLAU("_Blau",
+         "1.2.40.0.34.5.183",
+         "Blau",
+         "Blau",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: Durchgemachte Infektionskrankheit.<br>
+     */
+    DURCHGEMACHTE_INFEKTIONSKRANKHEIT_L1("161413004",
+                                         "2.16.840.1.113883.6.96",
+                                         "Durchgemachte Infektionskrankheit",
+                                         "Durchgemachte Infektionskrankheit",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Erfordert Impfung.<br>
+     */
+    ERFORDERT_IMPFUNG_L1("723620004",
+                         "2.16.840.1.113883.6.96",
+                         "Erfordert Impfung",
+                         "Erfordert Impfung",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Gelb.<br>
+     */
+    GELB("_Gelb",
+         "1.2.40.0.34.5.183",
+         "Gelb",
+         "Gelb",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: Grau.<br>
+     */
+    GRAU("_Grau",
+         "1.2.40.0.34.5.183",
+         "Grau",
+         "Grau",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: Grün.<br>
+     */
+    GR_N("_Grün",
+         "1.2.40.0.34.5.183",
+         "Grün",
+         "Grün",
+         "TOTRANSLATE",
+         "TOTRANSLATE",
+         "TOTRANSLATE"),
+    /**
+     * EN: Immunität erworben.<br>
+     */
+    IMMUNIT_T_ERWORBEN_L1("191441008",
+                          "2.16.840.1.113883.6.96",
+                          "Immunität erworben",
+                          "Immunität erworben",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Impfschutz auf dem neuesten Stand.<br>
+     */
+    IMPFSCHUTZ_AUF_DEM_NEUESTEN_STAND_L1("171258008",
+                                         "2.16.840.1.113883.6.96",
+                                         "Impfschutz auf dem neuesten Stand",
+                                         "Impfschutz auf dem neuesten Stand",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Impftermin anstehend.<br>
+     */
+    IMPFTERMIN_ANSTEHEND_L1("789539003",
+                            "2.16.840.1.113883.6.96",
+                            "Impftermin anstehend",
+                            "Impftermin anstehend",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Impfung überfällig.<br>
+     */
+    IMPFUNG_BERF_LLIG_L1("789540001",
+                         "2.16.840.1.113883.6.96",
+                         "Impfung überfällig",
+                         "Impfung überfällig",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Impfung fällig.<br>
+     */
+    IMPFUNG_F_LLIG_L1("171279008",
+                      "2.16.840.1.113883.6.96",
+                      "Impfung fällig",
+                      "Impfung fällig",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Impfung kontraindiziert.<br>
+     */
+    IMPFUNG_KONTRAINDIZIERT_L1("266758009",
+                               "2.16.840.1.113883.6.96",
+                               "Impfung kontraindiziert",
+                               "Impfung kontraindiziert",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Impfung notwendig.<br>
+     */
+    IMPFUNG_NOTWENDIG_L1("122541000119104",
+                         "2.16.840.1.113883.6.96",
+                         "Impfung notwendig",
+                         "Impfung notwendig",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Impfung verabreicht.<br>
+     */
+    IMPFUNG_VERABREICHT_L1("713404003",
+                           "2.16.840.1.113883.6.96",
+                           "Impfung verabreicht",
+                           "Impfung verabreicht",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Keine Aufzeichnungen über Impfungen.<br>
+     */
+    KEINE_AUFZEICHNUNGEN_BER_IMPFUNGEN_L1("171288004",
+                                          "2.16.840.1.113883.6.96",
+                                          "Keine Aufzeichnungen über Impfungen",
+                                          "Keine Aufzeichnungen über Impfungen",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE",
+                                          "TOTRANSLATE"),
+    /**
+     * EN: Rot.<br>
+     */
+    ROT("_Rot",
+        "1.2.40.0.34.5.183",
+        "Rot",
+        "Rot",
+        "TOTRANSLATE",
+        "TOTRANSLATE",
+        "TOTRANSLATE"),
+    /**
+     * EN: Unzureichende Immunität.<br>
+     */
+    UNZUREICHENDE_IMMUNIT_T_L1("424272000",
+                               "2.16.840.1.113883.6.96",
+                               "Unzureichende Immunität",
+                               "Unzureichende Immunität",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE");
+
+    /**
+     * EN: Code for Ausnahme.<br>
+     */
+    public static final String AUSNAHME_CODE = "_Ausnahme";
+
+    /**
+     * EN: Code for Blau.<br>
+     */
+    public static final String BLAU_CODE = "_Blau";
+
+    /**
+     * EN: Code for Durchgemachte Infektionskrankheit.<br>
+     */
+    public static final String DURCHGEMACHTE_INFEKTIONSKRANKHEIT_L1_CODE = "161413004";
+
+    /**
+     * EN: Code for Erfordert Impfung.<br>
+     */
+    public static final String ERFORDERT_IMPFUNG_L1_CODE = "723620004";
+
+    /**
+     * EN: Code for Gelb.<br>
+     */
+    public static final String GELB_CODE = "_Gelb";
+
+    /**
+     * EN: Code for Grau.<br>
+     */
+    public static final String GRAU_CODE = "_Grau";
+
+    /**
+     * EN: Code for Grün.<br>
+     */
+    public static final String GR_N_CODE = "_Grün";
+
+    /**
+     * EN: Code for Immunität erworben.<br>
+     */
+    public static final String IMMUNIT_T_ERWORBEN_L1_CODE = "191441008";
+
+    /**
+     * EN: Code for Impfschutz auf dem neuesten Stand.<br>
+     */
+    public static final String IMPFSCHUTZ_AUF_DEM_NEUESTEN_STAND_L1_CODE = "171258008";
+
+    /**
+     * EN: Code for Impftermin anstehend.<br>
+     */
+    public static final String IMPFTERMIN_ANSTEHEND_L1_CODE = "789539003";
+
+    /**
+     * EN: Code for Impfung überfällig.<br>
+     */
+    public static final String IMPFUNG_BERF_LLIG_L1_CODE = "789540001";
+
+    /**
+     * EN: Code for Impfung fällig.<br>
+     */
+    public static final String IMPFUNG_F_LLIG_L1_CODE = "171279008";
+
+    /**
+     * EN: Code for Impfung kontraindiziert.<br>
+     */
+    public static final String IMPFUNG_KONTRAINDIZIERT_L1_CODE = "266758009";
+
+    /**
+     * EN: Code for Impfung notwendig.<br>
+     */
+    public static final String IMPFUNG_NOTWENDIG_L1_CODE = "122541000119104";
+
+    /**
+     * EN: Code for Impfung verabreicht.<br>
+     */
+    public static final String IMPFUNG_VERABREICHT_L1_CODE = "713404003";
+
+    /**
+     * EN: Code for Keine Aufzeichnungen über Impfungen.<br>
+     */
+    public static final String KEINE_AUFZEICHNUNGEN_BER_IMPFUNGEN_L1_CODE = "171288004";
+
+    /**
+     * EN: Code for Rot.<br>
+     */
+    public static final String ROT_CODE = "_Rot";
+
+    /**
+     * EN: Code for Unzureichende Immunität.<br>
+     */
+    public static final String UNZUREICHENDE_IMMUNIT_T_L1_CODE = "424272000";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.3";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-specialcasevaccination";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.183";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfSpecialcasevaccination getEnum(@Nullable final String code) {
+        for (final EimpfSpecialcasevaccination x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfSpecialcasevaccination.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfSpecialcasevaccination x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfSpecialcasevaccination(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfSpecialsituationindication.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfSpecialsituationindication.java
@@ -1,0 +1,823 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of eimpf-specialsituationindication values
+ * <p>
+ * EN: No designation found.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.15<br>
+ * Effective date: 2023-08-03 00:00<br>
+ * Version: 2.7.0+20241115<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfSpecialsituationindication implements ValueSetEnumInterface {
+
+    /**
+     * EN: Allgemeine Bevölkerung.<br>
+     */
+    ALLGEMEINE_BEV_LKERUNG("_AllgemeineBevölkerung",
+                           "1.2.40.0.34.5.183",
+                           "Allgemeine Bevölkerung",
+                           "Allgemeine Bevölkerung",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Allgemeine Kategorisierung von Personen.<br>
+     */
+    ALLGEMEINE_KATEGORISIERUNG_VON_PERSONEN_L1("224627004",
+                                               "2.16.840.1.113883.6.96",
+                                               "Allgemeine Kategorisierung von Personen",
+                                               "Allgemeine Kategorisierung von Personen",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE",
+                                               "TOTRANSLATE"),
+    /**
+     * EN: Chikungunya Impfstoff.<br>
+     */
+    CHIKUNGUNYA_IMPFSTOFF("1345042009",
+                          "2.16.840.1.113883.6.96",
+                          "Chikungunya Impfstoff",
+                          "Chikungunya Impfstoff",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Cholera Impfstoff.<br>
+     */
+    CHOLERA_IMPFSTOFF_L1("836383009",
+                         "2.16.840.1.113883.6.96",
+                         "Cholera Impfstoff",
+                         "Cholera Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: COVID-19 Impfstoff.<br>
+     */
+    COVID_19_IMPFSTOFF_L1("840534001",
+                          "2.16.840.1.113883.6.96",
+                          "COVID-19 Impfstoff",
+                          "COVID-19 Impfstoff",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Dengue-Fieber Impfstoff.<br>
+     */
+    DENGUE_FIEBER_IMPFSTOFF_L1("840563003",
+                               "2.16.840.1.113883.6.96",
+                               "Dengue-Fieber Impfstoff",
+                               "Dengue-Fieber Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Diphtherie Impfstoff.<br>
+     */
+    DIPHTHERIE_IMPFSTOFF_L1("836381006",
+                            "2.16.840.1.113883.6.96",
+                            "Diphtherie Impfstoff",
+                            "Diphtherie Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Ebola Impfstoff.<br>
+     */
+    EBOLA_IMPFSTOFF("836421005",
+                    "2.16.840.1.113883.6.96",
+                    "Ebola Impfstoff",
+                    "Ebola Impfstoff",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Frühsommer-Meningoenzephalitis Impfstoff.<br>
+     */
+    FR_HSOMMER_MENINGOENZEPHALITIS_IMPFSTOFF_L1("836403007",
+                                                "2.16.840.1.113883.6.96",
+                                                "Frühsommer-Meningoenzephalitis Impfstoff",
+                                                "Frühsommer-Meningoenzephalitis Impfstoff",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE",
+                                                "TOTRANSLATE"),
+    /**
+     * EN: Gelbfieber Impfstoff.<br>
+     */
+    GELBFIEBER_IMPFSTOFF_L1("836385002",
+                            "2.16.840.1.113883.6.96",
+                            "Gelbfieber Impfstoff",
+                            "Gelbfieber Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Haemophilus influenzae Typ B Impfstoff.<br>
+     */
+    HAEMOPHILUS_INFLUENZAE_TYP_B_IMPFSTOFF_L1("836380007",
+                                              "2.16.840.1.113883.6.96",
+                                              "Haemophilus influenzae Typ B Impfstoff",
+                                              "Haemophilus influenzae Typ B Impfstoff",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis A Impfstoff.<br>
+     */
+    HEPATITIS_A_IMPFSTOFF_L1("836375003",
+                             "2.16.840.1.113883.6.96",
+                             "Hepatitis A Impfstoff",
+                             "Hepatitis A Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Hepatitis B Impfstoff.<br>
+     */
+    HEPATITIS_B_IMPFSTOFF_L1("836374004",
+                             "2.16.840.1.113883.6.96",
+                             "Hepatitis B Impfstoff",
+                             "Hepatitis B Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Herpes Zoster Impfstoff.<br>
+     */
+    HERPES_ZOSTER_IMPFSTOFF_L1("871919004",
+                               "2.16.840.1.113883.6.96",
+                               "Herpes Zoster Impfstoff",
+                               "Herpes Zoster Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Humane Papillomaviren Impfstoff.<br>
+     */
+    HUMANE_PAPILLOMAVIREN_IMPFSTOFF_L1("836379009",
+                                       "2.16.840.1.113883.6.96",
+                                       "Humane Papillomaviren Impfstoff",
+                                       "Humane Papillomaviren Impfstoff",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE"),
+    /**
+     * EN: Influenza (H1N1) Impfstoff.<br>
+     */
+    INFLUENZA_H1N1_IMPFSTOFF_L1("871772009",
+                                "2.16.840.1.113883.6.96",
+                                "Influenza (H1N1) Impfstoff",
+                                "Influenza (H1N1) Impfstoff",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Influenza (H5N1) Impfstoff.<br>
+     */
+    INFLUENZA_H5N1_IMPFSTOFF_L1("427036009",
+                                "2.16.840.1.113883.6.96",
+                                "Influenza (H5N1) Impfstoff",
+                                "Influenza (H5N1) Impfstoff",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Influenza H5 Impfstoff.<br>
+     */
+    INFLUENZA_H5_IMPFSTOFF("30041000234101",
+                           "2.16.840.1.113883.6.96",
+                           "Influenza H5 Impfstoff",
+                           "Influenza H5 Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Influenza Impfstoff.<br>
+     */
+    INFLUENZA_IMPFSTOFF_L1("836377006",
+                           "2.16.840.1.113883.6.96",
+                           "Influenza Impfstoff",
+                           "Influenza Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Japanische Enzephalitis Impfstoff.<br>
+     */
+    JAPANISCHE_ENZEPHALITIS_IMPFSTOFF_L1("836378001",
+                                         "2.16.840.1.113883.6.96",
+                                         "Japanische Enzephalitis Impfstoff",
+                                         "Japanische Enzephalitis Impfstoff",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Masern Impfstoff.<br>
+     */
+    MASERN_IMPFSTOFF_L1("836382004",
+                        "2.16.840.1.113883.6.96",
+                        "Masern Impfstoff",
+                        "Masern Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Impfstoff.<br>
+     */
+    MENINGOKOKKEN_IMPFSTOFF_L1("836401009",
+                               "2.16.840.1.113883.6.96",
+                               "Meningokokken Impfstoff",
+                               "Meningokokken Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp A+C Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_A_C_IMPFSTOFF_L1("871871008",
+                                           "2.16.840.1.113883.6.96",
+                                           "Meningokokken Serotyp A+C Impfstoff",
+                                           "Meningokokken Serotyp A+C Impfstoff",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp A+C+W135+Y Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_A_C_W135_Y_IMPFSTOFF_L1("871873006",
+                                                  "2.16.840.1.113883.6.96",
+                                                  "Meningokokken Serotyp A+C+W135+Y Impfstoff",
+                                                  "Meningokokken Serotyp A+C+W135+Y Impfstoff",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp B Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_B_IMPFSTOFF_L1("1981000221108",
+                                         "2.16.840.1.113883.6.96",
+                                         "Meningokokken Serotyp B Impfstoff",
+                                         "Meningokokken Serotyp B Impfstoff",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Meningokokken Serotyp C Impfstoff.<br>
+     */
+    MENINGOKOKKEN_SEROTYP_C_IMPFSTOFF_L1("871866001",
+                                         "2.16.840.1.113883.6.96",
+                                         "Meningokokken Serotyp C Impfstoff",
+                                         "Meningokokken Serotyp C Impfstoff",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE",
+                                         "TOTRANSLATE"),
+    /**
+     * EN: Mpox-/Pocken Impfstoff.<br>
+     */
+    MPOX_POCKEN_IMPFSTOFF_L1("836389008",
+                             "2.16.840.1.113883.6.96",
+                             "Mpox-/Pocken Impfstoff",
+                             "Mpox-/Pocken Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Mumps Impfstoff.<br>
+     */
+    MUMPS_IMPFSTOFF_L1("871738001",
+                       "2.16.840.1.113883.6.96",
+                       "Mumps Impfstoff",
+                       "Mumps Impfstoff",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Pertussis Impfstoff.<br>
+     */
+    PERTUSSIS_IMPFSTOFF_L1("601000221108",
+                           "2.16.840.1.113883.6.96",
+                           "Pertussis Impfstoff",
+                           "Pertussis Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Pneumokokken Impfstoff.<br>
+     */
+    PNEUMOKOKKEN_IMPFSTOFF_L1("836398006",
+                              "2.16.840.1.113883.6.96",
+                              "Pneumokokken Impfstoff",
+                              "Pneumokokken Impfstoff",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Poliomyelitis Impfstoff.<br>
+     */
+    POLIOMYELITIS_IMPFSTOFF_L1("1031000221108",
+                               "2.16.840.1.113883.6.96",
+                               "Poliomyelitis Impfstoff",
+                               "Poliomyelitis Impfstoff",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Respiratorische Synzytial-Virus Impfstoff.<br>
+     */
+    RESPIRATORISCHE_SYNZYTIAL_VIRUS_IMPFSTOFF_L1("108723008",
+                                                 "2.16.840.1.113883.6.96",
+                                                 "Respiratorische Synzytial-Virus Impfstoff",
+                                                 "Respiratorische Synzytial-Virus Impfstoff",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: Rotavirus Impfstoff.<br>
+     */
+    ROTAVIRUS_IMPFSTOFF_L1("836387005",
+                           "2.16.840.1.113883.6.96",
+                           "Rotavirus Impfstoff",
+                           "Rotavirus Impfstoff",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Röteln Impfstoff.<br>
+     */
+    R_TELN_IMPFSTOFF_L1("836388000",
+                        "2.16.840.1.113883.6.96",
+                        "Röteln Impfstoff",
+                        "Röteln Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Spezielle Risikogruppe für.<br>
+     */
+    SPEZIELLE_RISIKOGRUPPE_F_R("_SpezielleRisikogruppefür",
+                               "1.2.40.0.34.5.183",
+                               "Spezielle Risikogruppe für",
+                               "Spezielle Risikogruppe für",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Tetanus Impfstoff.<br>
+     */
+    TETANUS_IMPFSTOFF_L1("1101000221104",
+                         "2.16.840.1.113883.6.96",
+                         "Tetanus Impfstoff",
+                         "Tetanus Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Tollwut Impfstoff.<br>
+     */
+    TOLLWUT_IMPFSTOFF_L1("836393002",
+                         "2.16.840.1.113883.6.96",
+                         "Tollwut Impfstoff",
+                         "Tollwut Impfstoff",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Tuberkulose Impfstoff.<br>
+     */
+    TUBERKULOSE_IMPFSTOFF_L1("836402002",
+                             "2.16.840.1.113883.6.96",
+                             "Tuberkulose Impfstoff",
+                             "Tuberkulose Impfstoff",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Typhus Impfstoff.<br>
+     */
+    TYPHUS_IMPFSTOFF_L1("836390004",
+                        "2.16.840.1.113883.6.96",
+                        "Typhus Impfstoff",
+                        "Typhus Impfstoff",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Varizellen Impfstoff.<br>
+     */
+    VARIZELLEN_IMPFSTOFF_L1("836495005",
+                            "2.16.840.1.113883.6.96",
+                            "Varizellen Impfstoff",
+                            "Varizellen Impfstoff",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE");
+
+    /**
+     * EN: Code for Allgemeine Bevölkerung.<br>
+     */
+    public static final String ALLGEMEINE_BEV_LKERUNG_CODE = "_AllgemeineBevölkerung";
+
+    /**
+     * EN: Code for Allgemeine Kategorisierung von Personen.<br>
+     */
+    public static final String ALLGEMEINE_KATEGORISIERUNG_VON_PERSONEN_L1_CODE = "224627004";
+
+    /**
+     * EN: Code for Chikungunya Impfstoff.<br>
+     */
+    public static final String CHIKUNGUNYA_IMPFSTOFF_CODE = "1345042009";
+
+    /**
+     * EN: Code for Cholera Impfstoff.<br>
+     */
+    public static final String CHOLERA_IMPFSTOFF_L1_CODE = "836383009";
+
+    /**
+     * EN: Code for COVID-19 Impfstoff.<br>
+     */
+    public static final String COVID_19_IMPFSTOFF_L1_CODE = "840534001";
+
+    /**
+     * EN: Code for Dengue-Fieber Impfstoff.<br>
+     */
+    public static final String DENGUE_FIEBER_IMPFSTOFF_L1_CODE = "840563003";
+
+    /**
+     * EN: Code for Diphtherie Impfstoff.<br>
+     */
+    public static final String DIPHTHERIE_IMPFSTOFF_L1_CODE = "836381006";
+
+    /**
+     * EN: Code for Ebola Impfstoff.<br>
+     */
+    public static final String EBOLA_IMPFSTOFF_CODE = "836421005";
+
+    /**
+     * EN: Code for Frühsommer-Meningoenzephalitis Impfstoff.<br>
+     */
+    public static final String FR_HSOMMER_MENINGOENZEPHALITIS_IMPFSTOFF_L1_CODE = "836403007";
+
+    /**
+     * EN: Code for Gelbfieber Impfstoff.<br>
+     */
+    public static final String GELBFIEBER_IMPFSTOFF_L1_CODE = "836385002";
+
+    /**
+     * EN: Code for Haemophilus influenzae Typ B Impfstoff.<br>
+     */
+    public static final String HAEMOPHILUS_INFLUENZAE_TYP_B_IMPFSTOFF_L1_CODE = "836380007";
+
+    /**
+     * EN: Code for Hepatitis A Impfstoff.<br>
+     */
+    public static final String HEPATITIS_A_IMPFSTOFF_L1_CODE = "836375003";
+
+    /**
+     * EN: Code for Hepatitis B Impfstoff.<br>
+     */
+    public static final String HEPATITIS_B_IMPFSTOFF_L1_CODE = "836374004";
+
+    /**
+     * EN: Code for Herpes Zoster Impfstoff.<br>
+     */
+    public static final String HERPES_ZOSTER_IMPFSTOFF_L1_CODE = "871919004";
+
+    /**
+     * EN: Code for Humane Papillomaviren Impfstoff.<br>
+     */
+    public static final String HUMANE_PAPILLOMAVIREN_IMPFSTOFF_L1_CODE = "836379009";
+
+    /**
+     * EN: Code for Influenza (H1N1) Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H1N1_IMPFSTOFF_L1_CODE = "871772009";
+
+    /**
+     * EN: Code for Influenza (H5N1) Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H5N1_IMPFSTOFF_L1_CODE = "427036009";
+
+    /**
+     * EN: Code for Influenza H5 Impfstoff.<br>
+     */
+    public static final String INFLUENZA_H5_IMPFSTOFF_CODE = "30041000234101";
+
+    /**
+     * EN: Code for Influenza Impfstoff.<br>
+     */
+    public static final String INFLUENZA_IMPFSTOFF_L1_CODE = "836377006";
+
+    /**
+     * EN: Code for Japanische Enzephalitis Impfstoff.<br>
+     */
+    public static final String JAPANISCHE_ENZEPHALITIS_IMPFSTOFF_L1_CODE = "836378001";
+
+    /**
+     * EN: Code for Masern Impfstoff.<br>
+     */
+    public static final String MASERN_IMPFSTOFF_L1_CODE = "836382004";
+
+    /**
+     * EN: Code for Meningokokken Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_IMPFSTOFF_L1_CODE = "836401009";
+
+    /**
+     * EN: Code for Meningokokken Serotyp A+C Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_A_C_IMPFSTOFF_L1_CODE = "871871008";
+
+    /**
+     * EN: Code for Meningokokken Serotyp A+C+W135+Y Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_A_C_W135_Y_IMPFSTOFF_L1_CODE = "871873006";
+
+    /**
+     * EN: Code for Meningokokken Serotyp B Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_B_IMPFSTOFF_L1_CODE = "1981000221108";
+
+    /**
+     * EN: Code for Meningokokken Serotyp C Impfstoff.<br>
+     */
+    public static final String MENINGOKOKKEN_SEROTYP_C_IMPFSTOFF_L1_CODE = "871866001";
+
+    /**
+     * EN: Code for Mpox-/Pocken Impfstoff.<br>
+     */
+    public static final String MPOX_POCKEN_IMPFSTOFF_L1_CODE = "836389008";
+
+    /**
+     * EN: Code for Mumps Impfstoff.<br>
+     */
+    public static final String MUMPS_IMPFSTOFF_L1_CODE = "871738001";
+
+    /**
+     * EN: Code for Pertussis Impfstoff.<br>
+     */
+    public static final String PERTUSSIS_IMPFSTOFF_L1_CODE = "601000221108";
+
+    /**
+     * EN: Code for Pneumokokken Impfstoff.<br>
+     */
+    public static final String PNEUMOKOKKEN_IMPFSTOFF_L1_CODE = "836398006";
+
+    /**
+     * EN: Code for Poliomyelitis Impfstoff.<br>
+     */
+    public static final String POLIOMYELITIS_IMPFSTOFF_L1_CODE = "1031000221108";
+
+    /**
+     * EN: Code for Respiratorische Synzytial-Virus Impfstoff.<br>
+     */
+    public static final String RESPIRATORISCHE_SYNZYTIAL_VIRUS_IMPFSTOFF_L1_CODE = "108723008";
+
+    /**
+     * EN: Code for Rotavirus Impfstoff.<br>
+     */
+    public static final String ROTAVIRUS_IMPFSTOFF_L1_CODE = "836387005";
+
+    /**
+     * EN: Code for Röteln Impfstoff.<br>
+     */
+    public static final String R_TELN_IMPFSTOFF_L1_CODE = "836388000";
+
+    /**
+     * EN: Code for Spezielle Risikogruppe für.<br>
+     */
+    public static final String SPEZIELLE_RISIKOGRUPPE_F_R_CODE = "_SpezielleRisikogruppefür";
+
+    /**
+     * EN: Code for Tetanus Impfstoff.<br>
+     */
+    public static final String TETANUS_IMPFSTOFF_L1_CODE = "1101000221104";
+
+    /**
+     * EN: Code for Tollwut Impfstoff.<br>
+     */
+    public static final String TOLLWUT_IMPFSTOFF_L1_CODE = "836393002";
+
+    /**
+     * EN: Code for Tuberkulose Impfstoff.<br>
+     */
+    public static final String TUBERKULOSE_IMPFSTOFF_L1_CODE = "836402002";
+
+    /**
+     * EN: Code for Typhus Impfstoff.<br>
+     */
+    public static final String TYPHUS_IMPFSTOFF_L1_CODE = "836390004";
+
+    /**
+     * EN: Code for Varizellen Impfstoff.<br>
+     */
+    public static final String VARIZELLEN_IMPFSTOFF_L1_CODE = "836495005";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.15";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "eimpf-specialsituationindication";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfSpecialsituationindication getEnum(@Nullable final String code) {
+        for (final EimpfSpecialsituationindication x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfSpecialsituationindication.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfSpecialsituationindication x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfSpecialsituationindication(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfZusatzklassifikation.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/EimpfZusatzklassifikation.java
@@ -1,0 +1,403 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of  eimpf-zusatzklassifikation values
+ * <p>
+ * EN: No designation found.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.62<br>
+ * Effective date: 2023-08-08 00:00<br>
+ * Version: 3.4.0+20250107<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum EimpfZusatzklassifikation implements ValueSetEnumInterface {
+
+    /**
+     * EN: Arbeitsplatz/Betrieb.<br>
+     */
+    ARBEITSPLATZ_BETRIEB_L1("IS002",
+                            "1.2.40.0.34.5.183",
+                            "Arbeitsplatz/Betrieb",
+                            "Arbeitsplatz/Betrieb",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Betreute Wohneinrichtung.<br>
+     */
+    BETREUTE_WOHNEINRICHTUNG_L1("IS008",
+                                "1.2.40.0.34.5.183",
+                                "Betreute Wohneinrichtung",
+                                "Betreute Wohneinrichtung",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE",
+                                "TOTRANSLATE"),
+    /**
+     * EN: Bildungseinrichtung.<br>
+     */
+    BILDUNGSEINRICHTUNG_L1("IS001",
+                           "1.2.40.0.34.5.183",
+                           "Bildungseinrichtung",
+                           "Bildungseinrichtung",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Impfprogramm.<br>
+     */
+    IMPFPROGRAMM("IS009",
+                 "1.2.40.0.34.5.183",
+                 "Impfprogramm",
+                 "Impfprogramm",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Impfstelle (Impfsetting).<br>
+     */
+    IMPFSTELLE_IMPFSETTING("46224007",
+                           "2.16.840.1.113883.6.96",
+                           "Impfstelle (Impfsetting)",
+                           "Impfstelle (Impfsetting)",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Kostenfreies Impfprogramm.<br>
+     */
+    KOSTENFREIES_IMPFPROGRAMM_L1("IS010",
+                                 "1.2.40.0.34.5.183",
+                                 "Kostenfreies Impfprogramm",
+                                 "Kostenfreies Impfprogramm",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Krankenhaus inkl. Kur- und Rehaeinrichtungen.<br>
+     */
+    KRANKENHAUS_INKL_KUR_UND_REHAEINRICHTUNGEN_L1("IS003",
+                                                  "1.2.40.0.34.5.183",
+                                                  "Krankenhaus inkl. Kur- und Rehaeinrichtungen",
+                                                  "Krankenhaus inkl. Kur- und Rehaeinrichtungen",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE",
+                                                  "TOTRANSLATE"),
+    /**
+     * EN: Ordination.<br>
+     */
+    ORDINATION_L1("IS004",
+                  "1.2.40.0.34.5.183",
+                  "Ordination",
+                  "Ordination",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Wohnbereich.<br>
+     */
+    WOHNBEREICH_L1("IS006",
+                   "1.2.40.0.34.5.183",
+                   "Wohnbereich",
+                   "Wohnbereich",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Öffentliches Impfprogramm (ÖIP) Influenza.<br>
+     */
+    _FFENTLICHES_IMPFPROGRAMM_IP_INFLUENZA_L1("IS011",
+                                              "1.2.40.0.34.5.183",
+                                              "Öffentliches Impfprogramm (ÖIP) Influenza",
+                                              "Öffentliches Impfprogramm (ÖIP) Influenza",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE",
+                                              "TOTRANSLATE"),
+    /**
+     * EN: Öffentliche Impfstelle.<br>
+     */
+    _FFENTLICHE_IMPFSTELLE_L1("IS005",
+                              "1.2.40.0.34.5.183",
+                              "Öffentliche Impfstelle",
+                              "Öffentliche Impfstelle",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE",
+                              "TOTRANSLATE"),
+    /**
+     * EN: Öffentliche Impfstraße / Impfbus.<br>
+     */
+    _FFENTLICHE_IMPFSTRASSE_IMPFBUS_L1("IS007",
+                                       "1.2.40.0.34.5.183",
+                                       "Öffentliche Impfstraße / Impfbus",
+                                       "Öffentliche Impfstraße / Impfbus",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE",
+                                       "TOTRANSLATE");
+
+    /**
+     * EN: Code for Arbeitsplatz/Betrieb.<br>
+     */
+    public static final String ARBEITSPLATZ_BETRIEB_L1_CODE = "IS002";
+
+    /**
+     * EN: Code for Betreute Wohneinrichtung.<br>
+     */
+    public static final String BETREUTE_WOHNEINRICHTUNG_L1_CODE = "IS008";
+
+    /**
+     * EN: Code for Bildungseinrichtung.<br>
+     */
+    public static final String BILDUNGSEINRICHTUNG_L1_CODE = "IS001";
+
+    /**
+     * EN: Code for Impfprogramm.<br>
+     */
+    public static final String IMPFPROGRAMM_CODE = "IS009";
+
+    /**
+     * EN: Code for Impfstelle (Impfsetting).<br>
+     */
+    public static final String IMPFSTELLE_IMPFSETTING_CODE = "46224007";
+
+    /**
+     * EN: Code for Kostenfreies Impfprogramm.<br>
+     */
+    public static final String KOSTENFREIES_IMPFPROGRAMM_L1_CODE = "IS010";
+
+    /**
+     * EN: Code for Krankenhaus inkl. Kur- und Rehaeinrichtungen.<br>
+     */
+    public static final String KRANKENHAUS_INKL_KUR_UND_REHAEINRICHTUNGEN_L1_CODE = "IS003";
+
+    /**
+     * EN: Code for Ordination.<br>
+     */
+    public static final String ORDINATION_L1_CODE = "IS004";
+
+    /**
+     * EN: Code for Wohnbereich.<br>
+     */
+    public static final String WOHNBEREICH_L1_CODE = "IS006";
+
+    /**
+     * EN: Code for Öffentliches Impfprogramm (ÖIP) Influenza.<br>
+     */
+    public static final String _FFENTLICHES_IMPFPROGRAMM_IP_INFLUENZA_L1_CODE = "IS011";
+
+    /**
+     * EN: Code for Öffentliche Impfstelle.<br>
+     */
+    public static final String _FFENTLICHE_IMPFSTELLE_L1_CODE = "IS005";
+
+    /**
+     * EN: Code for Öffentliche Impfstraße / Impfbus.<br>
+     */
+    public static final String _FFENTLICHE_IMPFSTRASSE_IMPFBUS_L1_CODE = "IS007";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.62";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = " eimpf-zusatzklassifikation";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static EimpfZusatzklassifikation getEnum(@Nullable final String code) {
+        for (final EimpfZusatzklassifikation x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(EimpfZusatzklassifikation.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final EimpfZusatzklassifikation x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    EimpfZusatzklassifikation(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/ElgaEntitynamepartqualifier.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/ElgaEntitynamepartqualifier.java
@@ -1,0 +1,393 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of elga-entitynamepartqualifier values
+ * <p>
+ * EN: No designation found.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.6.0.10.8<br>
+ * Effective date: 2019-04-24 11:39<br>
+ * Version: 1.0.0+20230131<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum ElgaEntitynamepartqualifier implements ValueSetEnumInterface {
+
+    /**
+     * EN: academic.<br>
+     */
+    ACADEMIC("AC",
+             "2.16.840.1.113883.5.43",
+             "academic",
+             "academic",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: adopted.<br>
+     */
+    ADOPTED("AD",
+            "2.16.840.1.113883.5.43",
+            "adopted",
+            "adopted",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: birth.<br>
+     */
+    BIRTH("BR",
+          "2.16.840.1.113883.5.43",
+          "birth",
+          "birth",
+          "TOTRANSLATE",
+          "TOTRANSLATE",
+          "TOTRANSLATE"),
+    /**
+     * EN: callme.<br>
+     */
+    CALLME("CL",
+           "2.16.840.1.113883.5.43",
+           "callme",
+           "callme",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: initial.<br>
+     */
+    INITIAL("IN",
+            "2.16.840.1.113883.5.43",
+            "initial",
+            "initial",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Legal status.<br>
+     */
+    LEGAL_STATUS("LS",
+                 "2.16.840.1.113883.5.43",
+                 "Legal status",
+                 "Legal status",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: nobility.<br>
+     */
+    NOBILITY("NB",
+             "2.16.840.1.113883.5.43",
+             "nobility",
+             "nobility",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: professional.<br>
+     */
+    PROFESSIONAL("PR",
+                 "2.16.840.1.113883.5.43",
+                 "professional",
+                 "professional",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: spouse.<br>
+     */
+    SPOUSE("SP",
+           "2.16.840.1.113883.5.43",
+           "spouse",
+           "spouse",
+           "TOTRANSLATE",
+           "TOTRANSLATE",
+           "TOTRANSLATE"),
+    /**
+     * EN: title.<br>
+     */
+    TITLE("TITLE",
+          "2.16.840.1.113883.5.43",
+          "title",
+          "title",
+          "TOTRANSLATE",
+          "TOTRANSLATE",
+          "TOTRANSLATE"),
+    /**
+     * EN: voorvoegsel.<br>
+     */
+    VOORVOEGSEL("VV",
+                "2.16.840.1.113883.5.43",
+                "voorvoegsel",
+                "voorvoegsel",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE");
+
+    /**
+     * EN: Code for academic.<br>
+     */
+    public static final String ACADEMIC_CODE = "AC";
+
+    /**
+     * EN: Code for adopted.<br>
+     */
+    public static final String ADOPTED_CODE = "AD";
+
+    /**
+     * EN: Code for birth.<br>
+     */
+    public static final String BIRTH_CODE = "BR";
+
+    /**
+     * EN: Code for callme.<br>
+     */
+    public static final String CALLME_CODE = "CL";
+
+    /**
+     * EN: Code for initial.<br>
+     */
+    public static final String INITIAL_CODE = "IN";
+
+    /**
+     * EN: Code for Legal status.<br>
+     */
+    public static final String LEGAL_STATUS_CODE = "LS";
+
+    /**
+     * EN: Code for nobility.<br>
+     */
+    public static final String NOBILITY_CODE = "NB";
+
+    /**
+     * EN: Code for professional.<br>
+     */
+    public static final String PROFESSIONAL_CODE = "PR";
+
+    /**
+     * EN: Code for spouse.<br>
+     */
+    public static final String SPOUSE_CODE = "SP";
+
+    /**
+     * EN: Code for title.<br>
+     */
+    public static final String TITLE_CODE = "TITLE";
+
+    /**
+     * EN: Code for voorvoegsel.<br>
+     */
+    public static final String VOORVOEGSEL_CODE = "VV";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.6.0.10.8";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "elga-entitynamepartqualifier";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "2.16.840.1.113883.5.43";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static ElgaEntitynamepartqualifier getEnum(@Nullable final String code) {
+        for (final ElgaEntitynamepartqualifier x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(ElgaEntitynamepartqualifier.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final ElgaEntitynamepartqualifier x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    ElgaEntitynamepartqualifier(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/ElgaLanguagecode.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/ElgaLanguagecode.java
@@ -1,0 +1,1068 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of elga-languagecode values
+ * <p>
+ * EN: ELGA_LanguageCode is used to describe the language of the documents (CDA-Element: ClinicalDocument.languageCode). Description available under: http://www.ietf.org/rfc/rfc3066.txt.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.10.10<br>
+ * Effective date: 2022-12-02 10:15<br>
+ * Version: 2.0.0+20230131<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum ElgaLanguagecode implements ValueSetEnumInterface {
+
+    /**
+     * EN: Arabisch.<br>
+     */
+    ARABISCH("ar",
+             "2.16.840.1.113883.6.121",
+             "Arabisch",
+             "Arabisch",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Bengali.<br>
+     */
+    BENGALI("bn",
+            "2.16.840.1.113883.6.121",
+            "Bengali",
+            "Bengali",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Chinesisch.<br>
+     */
+    CHINESISCH("zh",
+               "2.16.840.1.113883.6.121",
+               "Chinesisch",
+               "Chinesisch",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Chinesisch (China).<br>
+     */
+    CHINESISCH_CHINA("zh-CN",
+                     "2.16.840.1.113883.6.121",
+                     "Chinesisch (China)",
+                     "Chinesisch (China)",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Chinesisch (Hong Kong).<br>
+     */
+    CHINESISCH_HONG_KONG("zh-HK",
+                         "2.16.840.1.113883.6.121",
+                         "Chinesisch (Hong Kong)",
+                         "Chinesisch (Hong Kong)",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Chinesisch (Singapur).<br>
+     */
+    CHINESISCH_SINGAPUR("zh-SG",
+                        "2.16.840.1.113883.6.121",
+                        "Chinesisch (Singapur)",
+                        "Chinesisch (Singapur)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Chinesisch (Taiwan).<br>
+     */
+    CHINESISCH_TAIWAN("zh-TW",
+                      "2.16.840.1.113883.6.121",
+                      "Chinesisch (Taiwan)",
+                      "Chinesisch (Taiwan)",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Deutsch.<br>
+     */
+    DEUTSCH("de",
+            "2.16.840.1.113883.6.121",
+            "Deutsch",
+            "Deutsch",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Deutsch (Deutschland).<br>
+     */
+    DEUTSCH_DEUTSCHLAND("de-DE",
+                        "2.16.840.1.113883.6.121",
+                        "Deutsch (Deutschland)",
+                        "Deutsch (Deutschland)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Deutsch (Schweiz).<br>
+     */
+    DEUTSCH_SCHWEIZ("de-CH",
+                    "2.16.840.1.113883.6.121",
+                    "Deutsch (Schweiz)",
+                    "Deutsch (Schweiz)",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Dänisch.<br>
+     */
+    D_NISCH("da",
+            "2.16.840.1.113883.6.121",
+            "Dänisch",
+            "Dänisch",
+            "TOTRANSLATE",
+            "TOTRANSLATE",
+            "TOTRANSLATE"),
+    /**
+     * EN: Englisch.<br>
+     */
+    ENGLISCH("en",
+             "2.16.840.1.113883.6.121",
+             "Englisch",
+             "Englisch",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Englisch (Australien).<br>
+     */
+    ENGLISCH_AUSTRALIEN("en-AU",
+                        "2.16.840.1.113883.6.121",
+                        "Englisch (Australien)",
+                        "Englisch (Australien)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Englisch (GB).<br>
+     */
+    ENGLISCH_GB("en-GB",
+                "2.16.840.1.113883.6.121",
+                "Englisch (GB)",
+                "Englisch (GB)",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Englisch (Indien).<br>
+     */
+    ENGLISCH_INDIEN("en-IN",
+                    "2.16.840.1.113883.6.121",
+                    "Englisch (Indien)",
+                    "Englisch (Indien)",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Englisch (Kanada).<br>
+     */
+    ENGLISCH_KANADA("en-CA",
+                    "2.16.840.1.113883.6.121",
+                    "Englisch (Kanada)",
+                    "Englisch (Kanada)",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Englisch (Neuseeland).<br>
+     */
+    ENGLISCH_NEUSEELAND("en-NZ",
+                        "2.16.840.1.113883.6.121",
+                        "Englisch (Neuseeland)",
+                        "Englisch (Neuseeland)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Englisch (Singapur).<br>
+     */
+    ENGLISCH_SINGAPUR("en-SG",
+                      "2.16.840.1.113883.6.121",
+                      "Englisch (Singapur)",
+                      "Englisch (Singapur)",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Englisch (US).<br>
+     */
+    ENGLISCH_US("en-US",
+                "2.16.840.1.113883.6.121",
+                "Englisch (US)",
+                "Englisch (US)",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Finnisch.<br>
+     */
+    FINNISCH("fi",
+             "2.16.840.1.113883.6.121",
+             "Finnisch",
+             "Finnisch",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Französisch.<br>
+     */
+    FRANZ_SISCH("fr",
+                "2.16.840.1.113883.6.121",
+                "Französisch",
+                "Französisch",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Französisch (Belgien).<br>
+     */
+    FRANZ_SISCH_BELGIEN("fr-BE",
+                        "2.16.840.1.113883.6.121",
+                        "Französisch (Belgien)",
+                        "Französisch (Belgien)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Französisch (Frankreich).<br>
+     */
+    FRANZ_SISCH_FRANKREICH("fr-FR",
+                           "2.16.840.1.113883.6.121",
+                           "Französisch (Frankreich)",
+                           "Französisch (Frankreich)",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Französisch (Schweiz).<br>
+     */
+    FRANZ_SISCH_SCHWEIZ("fr-CH",
+                        "2.16.840.1.113883.6.121",
+                        "Französisch (Schweiz)",
+                        "Französisch (Schweiz)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Friesisch.<br>
+     */
+    FRIESISCH("fy",
+              "2.16.840.1.113883.6.121",
+              "Friesisch",
+              "Friesisch",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Friesisch (Niederlande).<br>
+     */
+    FRIESISCH_NIEDERLANDE("fy-NL",
+                          "2.16.840.1.113883.6.121",
+                          "Friesisch (Niederlande)",
+                          "Friesisch (Niederlande)",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Hindi.<br>
+     */
+    HINDI("hi",
+          "2.16.840.1.113883.6.121",
+          "Hindi",
+          "Hindi",
+          "TOTRANSLATE",
+          "TOTRANSLATE",
+          "TOTRANSLATE"),
+    /**
+     * EN: Italienisch.<br>
+     */
+    ITALIENISCH("it",
+                "2.16.840.1.113883.6.121",
+                "Italienisch",
+                "Italienisch",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Italienisch (Italien).<br>
+     */
+    ITALIENISCH_ITALIEN("it-IT",
+                        "2.16.840.1.113883.6.121",
+                        "Italienisch (Italien)",
+                        "Italienisch (Italien)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Italienisch (Schweiz).<br>
+     */
+    ITALIENISCH_SCHWEIZ("it-CH",
+                        "2.16.840.1.113883.6.121",
+                        "Italienisch (Schweiz)",
+                        "Italienisch (Schweiz)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Japanisch.<br>
+     */
+    JAPANISCH("ja",
+              "2.16.840.1.113883.6.121",
+              "Japanisch",
+              "Japanisch",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Koreanisch.<br>
+     */
+    KOREANISCH("ko",
+               "2.16.840.1.113883.6.121",
+               "Koreanisch",
+               "Koreanisch",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Kroatisch.<br>
+     */
+    KROATISCH("hr",
+              "2.16.840.1.113883.6.121",
+              "Kroatisch",
+              "Kroatisch",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Neugriechisch.<br>
+     */
+    NEUGRIECHISCH("el",
+                  "2.16.840.1.113883.6.121",
+                  "Neugriechisch",
+                  "Neugriechisch",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Niederländisch.<br>
+     */
+    NIEDERL_NDISCH("nl",
+                   "2.16.840.1.113883.6.121",
+                   "Niederländisch",
+                   "Niederländisch",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Niederländisch (Belgien).<br>
+     */
+    NIEDERL_NDISCH_BELGIEN("nl-BE",
+                           "2.16.840.1.113883.6.121",
+                           "Niederländisch (Belgien)",
+                           "Niederländisch (Belgien)",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE",
+                           "TOTRANSLATE"),
+    /**
+     * EN: Niederländisch (Niederlande).<br>
+     */
+    NIEDERL_NDISCH_NIEDERLANDE("nl-NL",
+                               "2.16.840.1.113883.6.121",
+                               "Niederländisch (Niederlande)",
+                               "Niederländisch (Niederlande)",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Norwegisch.<br>
+     */
+    NORWEGISCH("no",
+               "2.16.840.1.113883.6.121",
+               "Norwegisch",
+               "Norwegisch",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Norwegisch (Norwegen).<br>
+     */
+    NORWEGISCH_NORWEGEN("no-NO",
+                        "2.16.840.1.113883.6.121",
+                        "Norwegisch (Norwegen)",
+                        "Norwegisch (Norwegen)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Pandschabi-Sprache.<br>
+     */
+    PANDSCHABI_SPRACHE("pa",
+                       "2.16.840.1.113883.6.121",
+                       "Pandschabi-Sprache",
+                       "Pandschabi-Sprache",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Polnisch.<br>
+     */
+    POLNISCH("pl",
+             "2.16.840.1.113883.6.121",
+             "Polnisch",
+             "Polnisch",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Portugiesisch.<br>
+     */
+    PORTUGIESISCH("pt",
+                  "2.16.840.1.113883.6.121",
+                  "Portugiesisch",
+                  "Portugiesisch",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Portugiesisch (Brasilien).<br>
+     */
+    PORTUGIESISCH_BRASILIEN("pt-BR",
+                            "2.16.840.1.113883.6.121",
+                            "Portugiesisch (Brasilien)",
+                            "Portugiesisch (Brasilien)",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE",
+                            "TOTRANSLATE"),
+    /**
+     * EN: Russisch.<br>
+     */
+    RUSSISCH("ru",
+             "2.16.840.1.113883.6.121",
+             "Russisch",
+             "Russisch",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Russisch (Russland).<br>
+     */
+    RUSSISCH_RUSSLAND("ru-RU",
+                      "2.16.840.1.113883.6.121",
+                      "Russisch (Russland)",
+                      "Russisch (Russland)",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Schwedisch.<br>
+     */
+    SCHWEDISCH("sv",
+               "2.16.840.1.113883.6.121",
+               "Schwedisch",
+               "Schwedisch",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Schwedisch (Schweden).<br>
+     */
+    SCHWEDISCH_SCHWEDEN("sv-SE",
+                        "2.16.840.1.113883.6.121",
+                        "Schwedisch (Schweden)",
+                        "Schwedisch (Schweden)",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE",
+                        "TOTRANSLATE"),
+    /**
+     * EN: Serbisch.<br>
+     */
+    SERBISCH("sr",
+             "2.16.840.1.113883.6.121",
+             "Serbisch",
+             "Serbisch",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Serbisch (Serbien).<br>
+     */
+    SERBISCH_SERBIEN("sr-RS",
+                     "2.16.840.1.113883.6.121",
+                     "Serbisch (Serbien)",
+                     "Serbisch (Serbien)",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Spanisch.<br>
+     */
+    SPANISCH("es",
+             "2.16.840.1.113883.6.121",
+             "Spanisch",
+             "Spanisch",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Spanisch (Argentinien).<br>
+     */
+    SPANISCH_ARGENTINIEN("es-AR",
+                         "2.16.840.1.113883.6.121",
+                         "Spanisch (Argentinien)",
+                         "Spanisch (Argentinien)",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Spanish (Spanien).<br>
+     */
+    SPANISH_SPANIEN("es-ES",
+                    "2.16.840.1.113883.6.121",
+                    "Spanish (Spanien)",
+                    "Spanish (Spanien)",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Spanish (Uruguay).<br>
+     */
+    SPANISH_URUGUAY("es-UY",
+                    "2.16.840.1.113883.6.121",
+                    "Spanish (Uruguay)",
+                    "Spanish (Uruguay)",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Telugu-Sprache.<br>
+     */
+    TELUGU_SPRACHE("te",
+                   "2.16.840.1.113883.6.121",
+                   "Telugu-Sprache",
+                   "Telugu-Sprache",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Tschechisch.<br>
+     */
+    TSCHECHISCH("cs",
+                "2.16.840.1.113883.6.121",
+                "Tschechisch",
+                "Tschechisch",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Österreichisches Deutsch.<br>
+     */
+    _STERREICHISCHES_DEUTSCH("de-AT",
+                             "2.16.840.1.113883.6.121",
+                             "Österreichisches Deutsch",
+                             "Österreichisches Deutsch",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE");
+
+    /**
+     * EN: Code for Arabisch.<br>
+     */
+    public static final String ARABISCH_CODE = "ar";
+
+    /**
+     * EN: Code for Bengali.<br>
+     */
+    public static final String BENGALI_CODE = "bn";
+
+    /**
+     * EN: Code for Chinesisch.<br>
+     */
+    public static final String CHINESISCH_CODE = "zh";
+
+    /**
+     * EN: Code for Chinesisch (China).<br>
+     */
+    public static final String CHINESISCH_CHINA_CODE = "zh-CN";
+
+    /**
+     * EN: Code for Chinesisch (Hong Kong).<br>
+     */
+    public static final String CHINESISCH_HONG_KONG_CODE = "zh-HK";
+
+    /**
+     * EN: Code for Chinesisch (Singapur).<br>
+     */
+    public static final String CHINESISCH_SINGAPUR_CODE = "zh-SG";
+
+    /**
+     * EN: Code for Chinesisch (Taiwan).<br>
+     */
+    public static final String CHINESISCH_TAIWAN_CODE = "zh-TW";
+
+    /**
+     * EN: Code for Deutsch.<br>
+     */
+    public static final String DEUTSCH_CODE = "de";
+
+    /**
+     * EN: Code for Deutsch (Deutschland).<br>
+     */
+    public static final String DEUTSCH_DEUTSCHLAND_CODE = "de-DE";
+
+    /**
+     * EN: Code for Deutsch (Schweiz).<br>
+     */
+    public static final String DEUTSCH_SCHWEIZ_CODE = "de-CH";
+
+    /**
+     * EN: Code for Dänisch.<br>
+     */
+    public static final String D_NISCH_CODE = "da";
+
+    /**
+     * EN: Code for Englisch.<br>
+     */
+    public static final String ENGLISCH_CODE = "en";
+
+    /**
+     * EN: Code for Englisch (Australien).<br>
+     */
+    public static final String ENGLISCH_AUSTRALIEN_CODE = "en-AU";
+
+    /**
+     * EN: Code for Englisch (GB).<br>
+     */
+    public static final String ENGLISCH_GB_CODE = "en-GB";
+
+    /**
+     * EN: Code for Englisch (Indien).<br>
+     */
+    public static final String ENGLISCH_INDIEN_CODE = "en-IN";
+
+    /**
+     * EN: Code for Englisch (Kanada).<br>
+     */
+    public static final String ENGLISCH_KANADA_CODE = "en-CA";
+
+    /**
+     * EN: Code for Englisch (Neuseeland).<br>
+     */
+    public static final String ENGLISCH_NEUSEELAND_CODE = "en-NZ";
+
+    /**
+     * EN: Code for Englisch (Singapur).<br>
+     */
+    public static final String ENGLISCH_SINGAPUR_CODE = "en-SG";
+
+    /**
+     * EN: Code for Englisch (US).<br>
+     */
+    public static final String ENGLISCH_US_CODE = "en-US";
+
+    /**
+     * EN: Code for Finnisch.<br>
+     */
+    public static final String FINNISCH_CODE = "fi";
+
+    /**
+     * EN: Code for Französisch.<br>
+     */
+    public static final String FRANZ_SISCH_CODE = "fr";
+
+    /**
+     * EN: Code for Französisch (Belgien).<br>
+     */
+    public static final String FRANZ_SISCH_BELGIEN_CODE = "fr-BE";
+
+    /**
+     * EN: Code for Französisch (Frankreich).<br>
+     */
+    public static final String FRANZ_SISCH_FRANKREICH_CODE = "fr-FR";
+
+    /**
+     * EN: Code for Französisch (Schweiz).<br>
+     */
+    public static final String FRANZ_SISCH_SCHWEIZ_CODE = "fr-CH";
+
+    /**
+     * EN: Code for Friesisch.<br>
+     */
+    public static final String FRIESISCH_CODE = "fy";
+
+    /**
+     * EN: Code for Friesisch (Niederlande).<br>
+     */
+    public static final String FRIESISCH_NIEDERLANDE_CODE = "fy-NL";
+
+    /**
+     * EN: Code for Hindi.<br>
+     */
+    public static final String HINDI_CODE = "hi";
+
+    /**
+     * EN: Code for Italienisch.<br>
+     */
+    public static final String ITALIENISCH_CODE = "it";
+
+    /**
+     * EN: Code for Italienisch (Italien).<br>
+     */
+    public static final String ITALIENISCH_ITALIEN_CODE = "it-IT";
+
+    /**
+     * EN: Code for Italienisch (Schweiz).<br>
+     */
+    public static final String ITALIENISCH_SCHWEIZ_CODE = "it-CH";
+
+    /**
+     * EN: Code for Japanisch.<br>
+     */
+    public static final String JAPANISCH_CODE = "ja";
+
+    /**
+     * EN: Code for Koreanisch.<br>
+     */
+    public static final String KOREANISCH_CODE = "ko";
+
+    /**
+     * EN: Code for Kroatisch.<br>
+     */
+    public static final String KROATISCH_CODE = "hr";
+
+    /**
+     * EN: Code for Neugriechisch.<br>
+     */
+    public static final String NEUGRIECHISCH_CODE = "el";
+
+    /**
+     * EN: Code for Niederländisch.<br>
+     */
+    public static final String NIEDERL_NDISCH_CODE = "nl";
+
+    /**
+     * EN: Code for Niederländisch (Belgien).<br>
+     */
+    public static final String NIEDERL_NDISCH_BELGIEN_CODE = "nl-BE";
+
+    /**
+     * EN: Code for Niederländisch (Niederlande).<br>
+     */
+    public static final String NIEDERL_NDISCH_NIEDERLANDE_CODE = "nl-NL";
+
+    /**
+     * EN: Code for Norwegisch.<br>
+     */
+    public static final String NORWEGISCH_CODE = "no";
+
+    /**
+     * EN: Code for Norwegisch (Norwegen).<br>
+     */
+    public static final String NORWEGISCH_NORWEGEN_CODE = "no-NO";
+
+    /**
+     * EN: Code for Pandschabi-Sprache.<br>
+     */
+    public static final String PANDSCHABI_SPRACHE_CODE = "pa";
+
+    /**
+     * EN: Code for Polnisch.<br>
+     */
+    public static final String POLNISCH_CODE = "pl";
+
+    /**
+     * EN: Code for Portugiesisch.<br>
+     */
+    public static final String PORTUGIESISCH_CODE = "pt";
+
+    /**
+     * EN: Code for Portugiesisch (Brasilien).<br>
+     */
+    public static final String PORTUGIESISCH_BRASILIEN_CODE = "pt-BR";
+
+    /**
+     * EN: Code for Russisch.<br>
+     */
+    public static final String RUSSISCH_CODE = "ru";
+
+    /**
+     * EN: Code for Russisch (Russland).<br>
+     */
+    public static final String RUSSISCH_RUSSLAND_CODE = "ru-RU";
+
+    /**
+     * EN: Code for Schwedisch.<br>
+     */
+    public static final String SCHWEDISCH_CODE = "sv";
+
+    /**
+     * EN: Code for Schwedisch (Schweden).<br>
+     */
+    public static final String SCHWEDISCH_SCHWEDEN_CODE = "sv-SE";
+
+    /**
+     * EN: Code for Serbisch.<br>
+     */
+    public static final String SERBISCH_CODE = "sr";
+
+    /**
+     * EN: Code for Serbisch (Serbien).<br>
+     */
+    public static final String SERBISCH_SERBIEN_CODE = "sr-RS";
+
+    /**
+     * EN: Code for Spanisch.<br>
+     */
+    public static final String SPANISCH_CODE = "es";
+
+    /**
+     * EN: Code for Spanisch (Argentinien).<br>
+     */
+    public static final String SPANISCH_ARGENTINIEN_CODE = "es-AR";
+
+    /**
+     * EN: Code for Spanish (Spanien).<br>
+     */
+    public static final String SPANISH_SPANIEN_CODE = "es-ES";
+
+    /**
+     * EN: Code for Spanish (Uruguay).<br>
+     */
+    public static final String SPANISH_URUGUAY_CODE = "es-UY";
+
+    /**
+     * EN: Code for Telugu-Sprache.<br>
+     */
+    public static final String TELUGU_SPRACHE_CODE = "te";
+
+    /**
+     * EN: Code for Tschechisch.<br>
+     */
+    public static final String TSCHECHISCH_CODE = "cs";
+
+    /**
+     * EN: Code for Österreichisches Deutsch.<br>
+     */
+    public static final String _STERREICHISCHES_DEUTSCH_CODE = "de-AT";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.10.10";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "elga-languagecode";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "2.16.840.1.113883.6.121";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static ElgaLanguagecode getEnum(@Nullable final String code) {
+        for (final ElgaLanguagecode x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(ElgaLanguagecode.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final ElgaLanguagecode x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    ElgaLanguagecode(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/ElgaPracticesetting.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/generated/artdecor/enums/ElgaPracticesetting.java
@@ -1,0 +1,858 @@
+/*
+ * This code is made available under the terms of the Eclipse Public License v1.0
+ * in the github project https://github.com/project-husky/husky there you also
+ * find a list of the contributors and the license information.
+ *
+ * This project has been developed further and modified by the joined working group Husky
+ * on the basis of the eHealth Connector opensource project from June 28, 2021,
+ * whereas medshare GmbH is the initial and main contributor/author of the eHealth Connector.
+ */
+package org.projecthusky.cda.elga.generated.artdecor.enums;
+
+import java.util.Objects;
+import javax.annotation.processing.Generated;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.projecthusky.common.enums.CodeSystems;
+import org.projecthusky.common.enums.LanguageCode;
+import org.projecthusky.common.enums.ValueSetEnumInterface;
+
+/**
+ * Enumeration of elga-practicesetting values
+ * <p>
+ * EN: Describes the assignment of a document to a medical area. These codes are used within XDS Metadata attribute "practiceSettingCode". Terminologies are inherited from "Österreichische Strukturplan Gesundheit" as far as possilbe. Opposite to this piece of work, some concepts are newly introduced. Where differentiation was reasonable, concepts were conducted in more detail. More concepts will be added if necessary, especially for physiotherapy, ergotherapy a.s.f.. A CDA implementation guide may specify the use of this codes. <br/>.<br>
+ * DE: No designation found.<br>
+ * FR: No designation found.<br>
+ * IT: No designation found.<br>
+ * <p>
+ * Identifier: 1.2.40.0.34.10.75<br>
+ * Effective date: 2020-05-25 09:52<br>
+ * Version: 202005(-beta)<br>
+ * Status: DRAFT
+ */
+@Generated(value = "org.projecthusky.codegenerator.ch.valuesets.UpdateValueSets", date = "2026-02-19")
+public enum ElgaPracticesetting implements ValueSetEnumInterface {
+
+    /**
+     * EN: Akutgeriatrie/Remobilisation.<br>
+     */
+    AKUTGERIATRIE_REMOBILISATION("F056",
+                                 "1.2.40.0.34.5.12",
+                                 "Akutgeriatrie/Remobilisation",
+                                 "Akutgeriatrie/Remobilisation",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Allgemeinmedizin.<br>
+     */
+    ALLGEMEINMEDIZIN("F001",
+                     "1.2.40.0.34.5.12",
+                     "Allgemeinmedizin",
+                     "Allgemeinmedizin",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Anästhesiologie und Intensivmedizin.<br>
+     */
+    AN_STHESIOLOGIE_UND_INTENSIVMEDIZIN("F002",
+                                        "1.2.40.0.34.5.12",
+                                        "Anästhesiologie und Intensivmedizin",
+                                        "Anästhesiologie und Intensivmedizin",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE",
+                                        "TOTRANSLATE"),
+    /**
+     * EN: Augenheilkunde.<br>
+     */
+    AUGENHEILKUNDE("F005",
+                   "1.2.40.0.34.5.12",
+                   "Augenheilkunde",
+                   "Augenheilkunde",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Blutgruppenserologie und Transfusionsmedizin.<br>
+     */
+    BLUTGRUPPENSEROLOGIE_UND_TRANSFUSIONSMEDIZIN("F006",
+                                                 "1.2.40.0.34.5.12",
+                                                 "Blutgruppenserologie und Transfusionsmedizin",
+                                                 "Blutgruppenserologie und Transfusionsmedizin",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE",
+                                                 "TOTRANSLATE"),
+    /**
+     * EN: Chirurgie.<br>
+     */
+    CHIRURGIE("F007",
+              "1.2.40.0.34.5.12",
+              "Chirurgie",
+              "Chirurgie",
+              "TOTRANSLATE",
+              "TOTRANSLATE",
+              "TOTRANSLATE"),
+    /**
+     * EN: Dermatologie.<br>
+     */
+    DERMATOLOGIE("F015",
+                 "1.2.40.0.34.5.12",
+                 "Dermatologie",
+                 "Dermatologie",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE",
+                 "TOTRANSLATE"),
+    /**
+     * EN: Gesundheits- und Krankenpflege.<br>
+     */
+    GESUNDHEITS_UND_KRANKENPFLEGE("F057",
+                                  "1.2.40.0.34.5.12",
+                                  "Gesundheits- und Krankenpflege",
+                                  "Gesundheits- und Krankenpflege",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Gynäkologie und Geburtshilfe.<br>
+     */
+    GYN_KOLOGIE_UND_GEBURTSHILFE("F010",
+                                 "1.2.40.0.34.5.12",
+                                 "Gynäkologie und Geburtshilfe",
+                                 "Gynäkologie und Geburtshilfe",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Hals-, Nasen- und Ohrenheilkunde.<br>
+     */
+    HALS_NASEN_UND_OHRENHEILKUNDE("F014",
+                                  "1.2.40.0.34.5.12",
+                                  "Hals-, Nasen- und Ohrenheilkunde",
+                                  "Hals-, Nasen- und Ohrenheilkunde",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE"),
+    /**
+     * EN: Herzchirurgie.<br>
+     */
+    HERZCHIRURGIE("F058",
+                  "1.2.40.0.34.5.12",
+                  "Herzchirurgie",
+                  "Herzchirurgie",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Innere Medizin.<br>
+     */
+    INNERE_MEDIZIN("F019",
+                   "1.2.40.0.34.5.12",
+                   "Innere Medizin",
+                   "Innere Medizin",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: InterdisziplinÃ¤rer Bereich.<br>
+     */
+    INTERDISZIPLIN_RER_BEREICH("F023",
+                               "1.2.40.0.34.5.12",
+                               "InterdisziplinÃ¤rer Bereich",
+                               "InterdisziplinÃ¤rer Bereich",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Kinder- und Jugendchirurgie.<br>
+     */
+    KINDER_UND_JUGENDCHIRURGIE("F026",
+                               "1.2.40.0.34.5.12",
+                               "Kinder- und Jugendchirurgie",
+                               "Kinder- und Jugendchirurgie",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Kinder- und Jugendheilkunde.<br>
+     */
+    KINDER_UND_JUGENDHEILKUNDE("F027",
+                               "1.2.40.0.34.5.12",
+                               "Kinder- und Jugendheilkunde",
+                               "Kinder- und Jugendheilkunde",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE",
+                               "TOTRANSLATE"),
+    /**
+     * EN: Kinder- und Jugendpsychiatrie.<br>
+     */
+    KINDER_UND_JUGENDPSYCHIATRIE("F025",
+                                 "1.2.40.0.34.5.12",
+                                 "Kinder- und Jugendpsychiatrie",
+                                 "Kinder- und Jugendpsychiatrie",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE",
+                                 "TOTRANSLATE"),
+    /**
+     * EN: Klinische Psychologie.<br>
+     */
+    KLINISCHE_PSYCHOLOGIE("F059",
+                          "1.2.40.0.34.5.12",
+                          "Klinische Psychologie",
+                          "Klinische Psychologie",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE",
+                          "TOTRANSLATE"),
+    /**
+     * EN: Krankenhauspflege.<br>
+     */
+    KRANKENHAUSPFLEGE("F066",
+                      "1.2.40.0.34.5.12",
+                      "Krankenhauspflege",
+                      "Krankenhauspflege",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE",
+                      "TOTRANSLATE"),
+    /**
+     * EN: Kur- und Prävention.<br>
+     */
+    KUR_UND_PR_VENTION("F060",
+                       "1.2.40.0.34.5.12",
+                       "Kur- und Prävention",
+                       "Kur- und Prävention",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE",
+                       "TOTRANSLATE"),
+    /**
+     * EN: Labordiagnostik.<br>
+     */
+    LABORDIAGNOSTIK("F028",
+                    "1.2.40.0.34.5.12",
+                    "Labordiagnostik",
+                    "Labordiagnostik",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Mikrobiologie.<br>
+     */
+    MIKROBIOLOGIE("F016",
+                  "1.2.40.0.34.5.12",
+                  "Mikrobiologie",
+                  "Mikrobiologie",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Mund-, Kiefer- und Gesichtschirurgie.<br>
+     */
+    MUND_KIEFER_UND_GESICHTSCHIRURGIE("F029",
+                                      "1.2.40.0.34.5.12",
+                                      "Mund-, Kiefer- und Gesichtschirurgie",
+                                      "Mund-, Kiefer- und Gesichtschirurgie",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE",
+                                      "TOTRANSLATE"),
+    /**
+     * EN: Neurochirurgie.<br>
+     */
+    NEUROCHIRURGIE("F031",
+                   "1.2.40.0.34.5.12",
+                   "Neurochirurgie",
+                   "Neurochirurgie",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Neurologie.<br>
+     */
+    NEUROLOGIE("F032",
+               "1.2.40.0.34.5.12",
+               "Neurologie",
+               "Neurologie",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Nuklearmedizin.<br>
+     */
+    NUKLEARMEDIZIN("F033",
+                   "1.2.40.0.34.5.12",
+                   "Nuklearmedizin",
+                   "Nuklearmedizin",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Orthopädie und orthopädische Chirurgie.<br>
+     */
+    ORTHOP_DIE_UND_ORTHOP_DISCHE_CHIRURGIE("F035",
+                                           "1.2.40.0.34.5.12",
+                                           "Orthopädie und orthopädische Chirurgie",
+                                           "Orthopädie und orthopädische Chirurgie",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE",
+                                           "TOTRANSLATE"),
+    /**
+     * EN: Palliativmedizin.<br>
+     */
+    PALLIATIVMEDIZIN("F036",
+                     "1.2.40.0.34.5.12",
+                     "Palliativmedizin",
+                     "Palliativmedizin",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE",
+                     "TOTRANSLATE"),
+    /**
+     * EN: Pathologie.<br>
+     */
+    PATHOLOGIE("F037",
+               "1.2.40.0.34.5.12",
+               "Pathologie",
+               "Pathologie",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Patienten Verwaltung.<br>
+     */
+    PATIENTEN_VERWALTUNG("F065",
+                         "1.2.40.0.34.5.12",
+                         "Patienten Verwaltung",
+                         "Patienten Verwaltung",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Physikalische Medizin und Rehabilitation.<br>
+     */
+    PHYSIKALISCHE_MEDIZIN_UND_REHABILITATION("F040",
+                                             "1.2.40.0.34.5.12",
+                                             "Physikalische Medizin und Rehabilitation",
+                                             "Physikalische Medizin und Rehabilitation",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE",
+                                             "TOTRANSLATE"),
+    /**
+     * EN: Plastische Chirurgie.<br>
+     */
+    PLASTISCHE_CHIRURGIE("F041",
+                         "1.2.40.0.34.5.12",
+                         "Plastische Chirurgie",
+                         "Plastische Chirurgie",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Psychiatrie.<br>
+     */
+    PSYCHIATRIE("F042",
+                "1.2.40.0.34.5.12",
+                "Psychiatrie",
+                "Psychiatrie",
+                "TOTRANSLATE",
+                "TOTRANSLATE",
+                "TOTRANSLATE"),
+    /**
+     * EN: Psychosomatik.<br>
+     */
+    PSYCHOSOMATIK("F061",
+                  "1.2.40.0.34.5.12",
+                  "Psychosomatik",
+                  "Psychosomatik",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE",
+                  "TOTRANSLATE"),
+    /**
+     * EN: Pulmologie.<br>
+     */
+    PULMOLOGIE("F043",
+               "1.2.40.0.34.5.12",
+               "Pulmologie",
+               "Pulmologie",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Radiologie.<br>
+     */
+    RADIOLOGIE("F044",
+               "1.2.40.0.34.5.12",
+               "Radiologie",
+               "Radiologie",
+               "TOTRANSLATE",
+               "TOTRANSLATE",
+               "TOTRANSLATE"),
+    /**
+     * EN: Radioonkologie.<br>
+     */
+    RADIOONKOLOGIE("F062",
+                   "1.2.40.0.34.5.12",
+                   "Radioonkologie",
+                   "Radioonkologie",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE",
+                   "TOTRANSLATE"),
+    /**
+     * EN: Rechtliche Dokumente.<br>
+     */
+    RECHTLICHE_DOKUMENTE("F063",
+                         "1.2.40.0.34.5.12",
+                         "Rechtliche Dokumente",
+                         "Rechtliche Dokumente",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE",
+                         "TOTRANSLATE"),
+    /**
+     * EN: Remobilisation/Nachsorge.<br>
+     */
+    REMOBILISATION_NACHSORGE("F048",
+                             "1.2.40.0.34.5.12",
+                             "Remobilisation/Nachsorge",
+                             "Remobilisation/Nachsorge",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE",
+                             "TOTRANSLATE"),
+    /**
+     * EN: Thoraxchirurgie.<br>
+     */
+    THORAXCHIRURGIE("F064",
+                    "1.2.40.0.34.5.12",
+                    "Thoraxchirurgie",
+                    "Thoraxchirurgie",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Unfallchirurgie.<br>
+     */
+    UNFALLCHIRURGIE("F052",
+                    "1.2.40.0.34.5.12",
+                    "Unfallchirurgie",
+                    "Unfallchirurgie",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE",
+                    "TOTRANSLATE"),
+    /**
+     * EN: Urologie.<br>
+     */
+    UROLOGIE("F053",
+             "1.2.40.0.34.5.12",
+             "Urologie",
+             "Urologie",
+             "TOTRANSLATE",
+             "TOTRANSLATE",
+             "TOTRANSLATE"),
+    /**
+     * EN: Zahn-, Mund- und Kieferheilkunde.<br>
+     */
+    ZAHN_MUND_UND_KIEFERHEILKUNDE("F055",
+                                  "1.2.40.0.34.5.12",
+                                  "Zahn-, Mund- und Kieferheilkunde",
+                                  "Zahn-, Mund- und Kieferheilkunde",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE",
+                                  "TOTRANSLATE");
+
+    /**
+     * EN: Code for Akutgeriatrie/Remobilisation.<br>
+     */
+    public static final String AKUTGERIATRIE_REMOBILISATION_CODE = "F056";
+
+    /**
+     * EN: Code for Allgemeinmedizin.<br>
+     */
+    public static final String ALLGEMEINMEDIZIN_CODE = "F001";
+
+    /**
+     * EN: Code for Anästhesiologie und Intensivmedizin.<br>
+     */
+    public static final String AN_STHESIOLOGIE_UND_INTENSIVMEDIZIN_CODE = "F002";
+
+    /**
+     * EN: Code for Augenheilkunde.<br>
+     */
+    public static final String AUGENHEILKUNDE_CODE = "F005";
+
+    /**
+     * EN: Code for Blutgruppenserologie und Transfusionsmedizin.<br>
+     */
+    public static final String BLUTGRUPPENSEROLOGIE_UND_TRANSFUSIONSMEDIZIN_CODE = "F006";
+
+    /**
+     * EN: Code for Chirurgie.<br>
+     */
+    public static final String CHIRURGIE_CODE = "F007";
+
+    /**
+     * EN: Code for Dermatologie.<br>
+     */
+    public static final String DERMATOLOGIE_CODE = "F015";
+
+    /**
+     * EN: Code for Gesundheits- und Krankenpflege.<br>
+     */
+    public static final String GESUNDHEITS_UND_KRANKENPFLEGE_CODE = "F057";
+
+    /**
+     * EN: Code for Gynäkologie und Geburtshilfe.<br>
+     */
+    public static final String GYN_KOLOGIE_UND_GEBURTSHILFE_CODE = "F010";
+
+    /**
+     * EN: Code for Hals-, Nasen- und Ohrenheilkunde.<br>
+     */
+    public static final String HALS_NASEN_UND_OHRENHEILKUNDE_CODE = "F014";
+
+    /**
+     * EN: Code for Herzchirurgie.<br>
+     */
+    public static final String HERZCHIRURGIE_CODE = "F058";
+
+    /**
+     * EN: Code for Innere Medizin.<br>
+     */
+    public static final String INNERE_MEDIZIN_CODE = "F019";
+
+    /**
+     * EN: Code for InterdisziplinÃ¤rer Bereich.<br>
+     */
+    public static final String INTERDISZIPLIN_RER_BEREICH_CODE = "F023";
+
+    /**
+     * EN: Code for Kinder- und Jugendchirurgie.<br>
+     */
+    public static final String KINDER_UND_JUGENDCHIRURGIE_CODE = "F026";
+
+    /**
+     * EN: Code for Kinder- und Jugendheilkunde.<br>
+     */
+    public static final String KINDER_UND_JUGENDHEILKUNDE_CODE = "F027";
+
+    /**
+     * EN: Code for Kinder- und Jugendpsychiatrie.<br>
+     */
+    public static final String KINDER_UND_JUGENDPSYCHIATRIE_CODE = "F025";
+
+    /**
+     * EN: Code for Klinische Psychologie.<br>
+     */
+    public static final String KLINISCHE_PSYCHOLOGIE_CODE = "F059";
+
+    /**
+     * EN: Code for Krankenhauspflege.<br>
+     */
+    public static final String KRANKENHAUSPFLEGE_CODE = "F066";
+
+    /**
+     * EN: Code for Kur- und Prävention.<br>
+     */
+    public static final String KUR_UND_PR_VENTION_CODE = "F060";
+
+    /**
+     * EN: Code for Labordiagnostik.<br>
+     */
+    public static final String LABORDIAGNOSTIK_CODE = "F028";
+
+    /**
+     * EN: Code for Mikrobiologie.<br>
+     */
+    public static final String MIKROBIOLOGIE_CODE = "F016";
+
+    /**
+     * EN: Code for Mund-, Kiefer- und Gesichtschirurgie.<br>
+     */
+    public static final String MUND_KIEFER_UND_GESICHTSCHIRURGIE_CODE = "F029";
+
+    /**
+     * EN: Code for Neurochirurgie.<br>
+     */
+    public static final String NEUROCHIRURGIE_CODE = "F031";
+
+    /**
+     * EN: Code for Neurologie.<br>
+     */
+    public static final String NEUROLOGIE_CODE = "F032";
+
+    /**
+     * EN: Code for Nuklearmedizin.<br>
+     */
+    public static final String NUKLEARMEDIZIN_CODE = "F033";
+
+    /**
+     * EN: Code for Orthopädie und orthopädische Chirurgie.<br>
+     */
+    public static final String ORTHOP_DIE_UND_ORTHOP_DISCHE_CHIRURGIE_CODE = "F035";
+
+    /**
+     * EN: Code for Palliativmedizin.<br>
+     */
+    public static final String PALLIATIVMEDIZIN_CODE = "F036";
+
+    /**
+     * EN: Code for Pathologie.<br>
+     */
+    public static final String PATHOLOGIE_CODE = "F037";
+
+    /**
+     * EN: Code for Patienten Verwaltung.<br>
+     */
+    public static final String PATIENTEN_VERWALTUNG_CODE = "F065";
+
+    /**
+     * EN: Code for Physikalische Medizin und Rehabilitation.<br>
+     */
+    public static final String PHYSIKALISCHE_MEDIZIN_UND_REHABILITATION_CODE = "F040";
+
+    /**
+     * EN: Code for Plastische Chirurgie.<br>
+     */
+    public static final String PLASTISCHE_CHIRURGIE_CODE = "F041";
+
+    /**
+     * EN: Code for Psychiatrie.<br>
+     */
+    public static final String PSYCHIATRIE_CODE = "F042";
+
+    /**
+     * EN: Code for Psychosomatik.<br>
+     */
+    public static final String PSYCHOSOMATIK_CODE = "F061";
+
+    /**
+     * EN: Code for Pulmologie.<br>
+     */
+    public static final String PULMOLOGIE_CODE = "F043";
+
+    /**
+     * EN: Code for Radiologie.<br>
+     */
+    public static final String RADIOLOGIE_CODE = "F044";
+
+    /**
+     * EN: Code for Radioonkologie.<br>
+     */
+    public static final String RADIOONKOLOGIE_CODE = "F062";
+
+    /**
+     * EN: Code for Rechtliche Dokumente.<br>
+     */
+    public static final String RECHTLICHE_DOKUMENTE_CODE = "F063";
+
+    /**
+     * EN: Code for Remobilisation/Nachsorge.<br>
+     */
+    public static final String REMOBILISATION_NACHSORGE_CODE = "F048";
+
+    /**
+     * EN: Code for Thoraxchirurgie.<br>
+     */
+    public static final String THORAXCHIRURGIE_CODE = "F064";
+
+    /**
+     * EN: Code for Unfallchirurgie.<br>
+     */
+    public static final String UNFALLCHIRURGIE_CODE = "F052";
+
+    /**
+     * EN: Code for Urologie.<br>
+     */
+    public static final String UROLOGIE_CODE = "F053";
+
+    /**
+     * EN: Code for Zahn-, Mund- und Kieferheilkunde.<br>
+     */
+    public static final String ZAHN_MUND_UND_KIEFERHEILKUNDE_CODE = "F055";
+
+    /**
+     * Identifier of the value set.
+     */
+    public static final String VALUE_SET_ID = "1.2.40.0.34.10.75";
+
+    /**
+     * Name of the value set.
+     */
+    public static final String VALUE_SET_NAME = "elga-practicesetting";
+
+    /**
+     * Identifier of the code system (all values share the same).
+     */
+    public static final String CODE_SYSTEM_ID = "1.2.40.0.34.5.12";
+
+    /**
+     * Gets the Enum with a given code.
+     *
+     * @param code The code value.
+     * @return the enum value found or {@code null}.
+     */
+    @Nullable
+    public static ElgaPracticesetting getEnum(@Nullable final String code) {
+        for (final ElgaPracticesetting x : values()) {
+            if (x.getCodeValue().equals(code)) {
+                return x;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a given enum is part of this value set.
+     *
+     * @param enumName The name of the enum.
+     * @return {@code true} if the name is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isEnumOfValueSet(@Nullable final String enumName) {
+        if (enumName == null) {
+            return false;
+        }
+        try {
+            Enum.valueOf(ElgaPracticesetting.class,
+                         enumName);
+            return true;
+        } catch (final IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Checks if a given code value is in this value set.
+     *
+     * @param codeValue The code value.
+     * @return {@code true} if the value is found in this value set, {@code false} otherwise.
+     */
+    public static boolean isInValueSet(@Nullable final String codeValue) {
+        for (final ElgaPracticesetting x : values()) {
+            if (x.getCodeValue().equals(codeValue)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Machine interpretable and (inside this class) unique code.
+     */
+    @NonNull
+    private final String code;
+
+    /**
+     * Identifier of the referencing code system.
+     */
+    @NonNull
+    private final String codeSystem;
+
+    /**
+     * The display names per language. It's always stored in the given order: default display name (0), in English (1),
+     * in German (2), in French (3) and in Italian (4).
+     */
+    @NonNull
+    private final String[] displayNames;
+
+    /**
+     * Instantiates this enum with a given code and display names.
+     *
+     * @param code          The code value.
+     * @param codeSystem    The code system (OID).
+     * @param displayName   The default display name.
+     * @param displayNameEn The display name in English.
+     * @param displayNameDe The display name in German.
+     * @param displayNameFr The display name in French.
+     * @param displayNameIt The display name in Italian.
+     */
+    ElgaPracticesetting(@NonNull final String code, @NonNull final String codeSystem, @NonNull final String displayName, @NonNull final String displayNameEn, @NonNull final String displayNameDe, @NonNull final String displayNameFr, @NonNull final String displayNameIt) {
+        this.code = Objects.requireNonNull(code);
+        this.codeSystem = Objects.requireNonNull(codeSystem);
+        this.displayNames = new String[5];
+        this.displayNames[0] = Objects.requireNonNull(displayName);
+        this.displayNames[1] = Objects.requireNonNull(displayNameEn);
+        this.displayNames[2] = Objects.requireNonNull(displayNameDe);
+        this.displayNames[3] = Objects.requireNonNull(displayNameFr);
+        this.displayNames[4] = Objects.requireNonNull(displayNameIt);
+    }
+
+    /**
+     * Gets the code system identifier.
+     *
+     * @return the code system identifier.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemId() {
+        return this.codeSystem;
+    }
+
+    /**
+     * Gets the code system name.
+     *
+     * @return the code system name.
+     */
+    @Override
+    @NonNull
+    public String getCodeSystemName() {
+        final var codeSystem = CodeSystems.getEnum(this.codeSystem);
+        if (codeSystem != null) {
+            return codeSystem.getCodeSystemName();
+        }
+        return "";
+    }
+
+    /**
+     * Gets the code value as a string.
+     *
+     * @return the code value.
+     */
+    @Override
+    @NonNull
+    public String getCodeValue() {
+        return this.code;
+    }
+
+    /**
+     * Gets the display name defined by the language param.
+     *
+     * @param languageCode The language code to get the display name for, {@code null} to get the default display name.
+     * @return the display name in the desired language.
+     */
+    @Override
+    @NonNull
+    public String getDisplayName(@Nullable final LanguageCode languageCode) {
+        if (languageCode == null) {
+            return this.displayNames[0];
+        }
+        return switch(languageCode) {
+            case ENGLISH ->
+                this.displayNames[1];
+            case GERMAN ->
+                this.displayNames[2];
+            case FRENCH ->
+                this.displayNames[3];
+            case ITALIAN ->
+                this.displayNames[4];
+            default ->
+                "TOTRANSLATE";
+        };
+    }
+
+    /**
+     * Gets the value set identifier.
+     *
+     * @return the value set identifier.
+     */
+    @Override
+    @NonNull
+    public String getValueSetId() {
+        return VALUE_SET_ID;
+    }
+
+    /**
+     * Gets the value set name.
+     *
+     * @return the value set name.
+     */
+    @Override
+    @NonNull
+    public String getValueSetName() {
+        return VALUE_SET_NAME;
+    }
+}

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/narrative/ImmunizationBaseTextGenerator.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/narrative/ImmunizationBaseTextGenerator.java
@@ -80,12 +80,13 @@ public class ImmunizationBaseTextGenerator extends BaseTextGenerator {
 		return list;
 	}
 
-	protected StrucDocTr getRowDose(POCDMT000040Precondition precondition) {
+	protected StrucDocTr getRowDose(POCDMT000040Precondition precondition, int index) {
 		StrucDocTr tr = new StrucDocTr();
 		tr.getThOrTd().add(getCellTd("Dosis:"));
 		if (precondition != null && precondition.getCriterion() != null
-				&& precondition.getCriterion().getValue() instanceof CD code) {
-			tr.getThOrTd().add(getCellTd(code.getDisplayName()));
+						&& precondition.getCriterion().getValue() instanceof CD code) {
+			String contentId = String.format("dose-immunization-%d", index);
+			tr.getThOrTd().add(getCellTdWithContent(code.getDisplayName(), contentId));
 		}
 
 		return tr;

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/narrative/ImmunizationNarrativeTextGenerator.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/narrative/ImmunizationNarrativeTextGenerator.java
@@ -129,7 +129,7 @@ public class ImmunizationNarrativeTextGenerator extends ImmunizationBaseTextGene
 		return tr;
 	}
 
-	protected StrucDocTr getRowVaccine(POCDMT000040Consumable vaccine) {
+	protected StrucDocTr getRowVaccine(POCDMT000040Consumable vaccine, int index) {
 		if (vaccine != null && vaccine.getManufacturedProduct() != null
 				&& vaccine.getManufacturedProduct().getManufacturedMaterial() != null
 				&& vaccine.getManufacturedProduct().getManufacturedMaterial().getCode() != null) {
@@ -137,6 +137,8 @@ public class ImmunizationNarrativeTextGenerator extends ImmunizationBaseTextGene
 			tr.getThOrTd().add(getCellTd("Impfstoff:"));
 			tr.getThOrTd().add(
 					getCellTd(vaccine.getManufacturedProduct().getManufacturedMaterial().getCode().getDisplayName()));
+			String contentId = String.format("manufactured-material-%d", index);
+			tr.getThOrTd().add(getCellTdWithContent(vaccine.getManufacturedProduct().getManufacturedMaterial().getCode().getDisplayName(), contentId));
 			return tr;
 		}
 
@@ -176,13 +178,13 @@ public class ImmunizationNarrativeTextGenerator extends ImmunizationBaseTextGene
 
 		for (POCDMT000040Precondition precondition : substanceAdministration.getPrecondition()) {
 			if (precondition != null) {
-				body.getTr().add(getRowDose(precondition));
+				body.getTr().add(getRowDose(precondition, idxImmunization));
 				body.getTr().add(getRowScheme(precondition, idxImmunization));
 			}
 		}
 
 		if (substanceAdministration.getConsumable() != null) {
-			body.getTr().add(getRowVaccine(substanceAdministration.getConsumable()));
+			body.getTr().add(getRowVaccine(substanceAdministration.getConsumable(), idxImmunization));
 		}
 
 		body.getTr().addAll(getRowTargetDiseases(substanceAdministration.getEntryRelationship()));

--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/narrative/ImmunizationRecommendationNarrativeTextGenerator.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/narrative/ImmunizationRecommendationNarrativeTextGenerator.java
@@ -61,7 +61,7 @@ public class ImmunizationRecommendationNarrativeTextGenerator extends Immunizati
 
 		for (POCDMT000040Precondition precondition : substanceAdministration.getPrecondition()) {
 			if (precondition != null) {
-				body.getTr().add(getRowDose(precondition));
+				body.getTr().add(getRowDose(precondition, idxImmunization));
 				body.getTr().add(getRowScheme(precondition, idxImmunization));
 			}
 		}

--- a/husky-common/husky-common-at/src/main/java/org/projecthusky/common/at/enums/FormatCode.java
+++ b/husky-common/husky-common-at/src/main/java/org/projecthusky/common/at/enums/FormatCode.java
@@ -236,7 +236,13 @@ public enum FormatCode implements ValueSetEnumInterfaceAt {
 	ELGA_PHC_2017("urn:elga:phc:2017", "PHC Statusbericht", "PHC Statusbericht"),
 
 	ELGA_IMMUNIZATION_RECORD_2019("urn:hl7-at:eImpf:2019", "HL7 Austria e-Impfpass 2019",
-			"HL7 Austria e-Impfpass 2019");
+			"HL7 Austria e-Impfpass 2019"),
+
+	ELGA_IMMUNIZATION_RECORD_20230717("urn:hl7-at:eImpf:2.0.0+20230717", "HL7 Austria e-Impfpass 2.0.0+20230717",
+			"HL7 Austria e-Impfpass 2.0.0+20230717"),
+
+	ELGA_IMMUNIZATION_RECORD_20260204("urn:hl7-at:eImpf:2.0.2+20260204", "HL7 Austria e-Impfpass 2.0.2+20260204",
+			"HL7 Austria e-Impfpass 2.0.2+20260204");
 
 	/**
 	 * Identifier of the value set

--- a/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/utils/XdsMetadataUtil.java
+++ b/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/utils/XdsMetadataUtil.java
@@ -312,16 +312,8 @@ public class XdsMetadataUtil {
 			// Speciality
 			if (!at.getAuthorSpecialty().isEmpty()
 					&& at.getAuthorSpecialty().get(0) != null) {
-				String specialtySystem = "";
-				if (at.getAuthorSpecialty().get(0).getAssigningAuthority() != null) {
-					specialtySystem = at.getAuthorSpecialty().get(0).getAssigningAuthority().getUniversalId();
-				} else {
-					// Coming from a CDA for ELGA the specialty is a CE (coding element), thus it has no assigningAuthority.
-					// Thus, I have to hard code the system here, since it got lost somewhere along the way.
-					specialtySystem = "1.2.40.0.34.10.6";
-				}
 				a.setSpeciality(new Code(at.getAuthorSpecialty().get(0).getId(),
-						specialtySystem, null));
+						at.getAuthorSpecialty().get(0).getAssigningAuthority().getUniversalId(), null));
 			}
 
 			// Telecoms

--- a/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/utils/XdsMetadataUtil.java
+++ b/husky-common/husky-common-gen/src/main/java/org/projecthusky/common/utils/XdsMetadataUtil.java
@@ -312,8 +312,16 @@ public class XdsMetadataUtil {
 			// Speciality
 			if (!at.getAuthorSpecialty().isEmpty()
 					&& at.getAuthorSpecialty().get(0) != null) {
+				String specialtySystem = "";
+				if (at.getAuthorSpecialty().get(0).getAssigningAuthority() != null) {
+					specialtySystem = at.getAuthorSpecialty().get(0).getAssigningAuthority().getUniversalId();
+				} else {
+					// Coming from a CDA for ELGA the specialty is a CE (coding element), thus it has no assigningAuthority.
+					// Thus, I have to hard code the system here, since it got lost somewhere along the way.
+					specialtySystem = "1.2.40.0.34.10.6";
+				}
 				a.setSpeciality(new Code(at.getAuthorSpecialty().get(0).getId(),
-						at.getAuthorSpecialty().get(0).getAssigningAuthority().getUniversalId(), null));
+						specialtySystem, null));
 			}
 
 			// Telecoms


### PR DESCRIPTION
resolves #338 

ELGA published and now also enforces a new CDA implementation guide for e-immunizations (https://wiki.hl7.at/index.php?title=ILF:E-Impfpass_(Version_2)).
Since the e-connector of ET-Innovations utilizes Husky for that, some adaptions are needed.

- added new ELGA classes which were created using the Husky code-generator
- new e-immunization format code was added
- updated `Immunization*TextGenerators`
- added a hack to husky-common\husky-common-gen\src\main\java\org\projecthusky\common\utils\XdsMetadataUtil.java => There is a difference between a CDA document from ELGA & how Husky treats it regarding `AuthorSpecialty`. This hack should break no other cases, as I only added a fallback. See  https://github.com/project-husky/husky/commit/3dc4df9c247df5079baaf48e246600ebeda49beb