### PR TITLE
[#378] fix `CdaDocumentMarshaller`

### DIFF
--- a/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/xml/CdaDocumentMarshaller.java
+++ b/husky-cda/husky-elga/src/main/java/org/projecthusky/cda/elga/xml/CdaDocumentMarshaller.java
@@ -48,7 +48,7 @@ public class CdaDocumentMarshaller {
         final var marshaller = jaxbContext.createMarshaller();
         marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
         marshaller.setProperty(Marshaller.JAXB_ENCODING, "UTF-8");
-		marshaller.setProperty("com.sun.xml.bind.xmlHeaders",
+		marshaller.setProperty("org.glassfish.jaxb.xmlHeaders",
 				String.format("<?xml-stylesheet type='text/xsl' href='%s' ?>", stylesheet));
 
 		final var writer = new StringWriter();

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<bouncycastle.version>1.83</bouncycastle.version>
 		<logback.version>1.5.16</logback.version>
 		<apache_poi_version>5.4.1</apache_poi_version>
-		<cxf.version>4.1.7</cxf.version>
+		<cxf.version>4.1.8</cxf.version>
 	</properties>
 	<scm>
 		<connection>scm:git:https://github.com/project-husky/husky.git</connection>
@@ -301,6 +301,12 @@
 				<groupId>org.apache.httpcomponents.core5</groupId>
 				<version>${apache-httpcore5}</version>
 				<artifactId>httpcore5</artifactId>
+			</dependency>
+			
+			<dependency>
+			    <groupId>org.apache.thrift</groupId>
+			    <artifactId>libthrift</artifactId>
+			    <version>0.24.0</version>
 			</dependency>
 
 			<!-- XUA stuff -->


### PR DESCRIPTION
The property `com.sun.xml.bind.xmlHeaders` was not recognized by jaxb-runtime 4.0.5,
causing a PropertyException and a null CDA output.

Fixed by replacing it with the new `org.glassfish.jaxb.xmlHeaders` property.